### PR TITLE
feat(token): rename Source to Input, extract Renderable interface, and update BaseToken

### DIFF
--- a/internal/build/token/base_test.go
+++ b/internal/build/token/base_test.go
@@ -294,7 +294,7 @@ func TestBaseToken(t *testing.T) {
 					}
 				})
 
-				t.Run("Source", func(t *testing.T) {
+				t.Run("input", func(t *testing.T) {
 					b := &token.BaseToken{Name: "id", Alias: "uid"}
 					err := fmt.Errorf("alias conflict")
 					b.SetError("id AS uid", err)
@@ -302,8 +302,8 @@ func TestBaseToken(t *testing.T) {
 					if b.Error == nil || b.Error.Error() != "alias conflict" {
 						t.Errorf("expected error 'alias conflict', got %v", b.Error)
 					}
-					if b.Source != "id AS uid" {
-						t.Errorf("expected source to be 'id AS uid', got %q", b.Source)
+					if b.GetInput() != "id AS uid" {
+						t.Errorf("expected source to be 'id AS uid', got %q", b.GetInput())
 					}
 				})
 
@@ -311,14 +311,14 @@ func TestBaseToken(t *testing.T) {
 					b := token.NewBaseToken("users.id")
 					b.SetError("ignored", fmt.Errorf("structural error"))
 
-					if b.Source != "ignored" {
-						t.Errorf("expected source to remain 'ignored', got %q", b.Source)
+					if b.GetInput() != "ignored" {
+						t.Errorf("expected source to remain 'ignored', got %q", b.GetInput())
 					}
 				})
 			})
 
 			t.Run("SetErrorWith", func(t *testing.T) {
-				t.Run("Source", func(t *testing.T) {
+				t.Run("input", func(t *testing.T) {
 					b := token.NewBaseToken("id", "uid")
 					err := fmt.Errorf("alias conflict")
 					b.SetErrorWith("id AS uid", err)
@@ -326,8 +326,8 @@ func TestBaseToken(t *testing.T) {
 					if b.GetError() == nil || b.GetError().Error() != "alias conflict" {
 						t.Errorf("expected error 'alias conflict', got %v", b.Error)
 					}
-					if b.Source != "id AS uid" {
-						t.Errorf("expected source to be 'id AS uid', got %q", b.Source)
+					if b.GetInput() != "id AS uid" {
+						t.Errorf("expected source to be 'id AS uid', got %q", b.GetInput())
 					}
 				})
 			})
@@ -390,13 +390,9 @@ func TestBaseToken(t *testing.T) {
 				})
 
 				t.Run("WithError", func(t *testing.T) {
-					b := &token.BaseToken{
-						Name:  "id",
-						Alias: "uid",
-						Error: fmt.Errorf("conflict"),
-					}
+					b := token.NewBaseToken("id AS uid", "user_id")
 					out := b.String()
-					if !strings.Contains(out, "errored: true") || !strings.Contains(out, "error: conflict") {
+					if !strings.Contains(out, "errored: true") || !strings.Contains(out, "error: alias conflict") {
 						t.Errorf("expected error details, got %q", out)
 					}
 				})
@@ -411,8 +407,8 @@ func TestBaseToken(t *testing.T) {
 				} else if b.Error.Error() != "invalid input expression: expression is empty" {
 					t.Errorf("unexpected error message: %s", b.Error)
 				}
-				if b.Source != "" {
-					t.Errorf("expected Source to be empty, got %q", b.Source)
+				if b.GetInput() != "" {
+					t.Errorf("expected input to be empty, got %q", b.GetInput())
 				}
 			})
 

--- a/internal/build/token/generic.go
+++ b/internal/build/token/generic.go
@@ -50,18 +50,4 @@ type GenericToken interface {
 	// A token is considered valid if it has a resolvable identifier
 	// (e.g., non-empty Name) and no internal Error state.
 	IsValid() bool
-
-	// Raw returns the dialect-neutral, unquoted SQL expression that
-	// represents the token (e.g., "id", "users.name").
-	//
-	// This value should not include aliases or dialect-specific formatting.
-	Raw() string
-
-	// String returns a developer-facing representation of the token,
-	// suitable for logging, test diffs, or debug output.
-	//
-	// Example output:
-	//   Column("id") [aliased: false, qualified: false]
-	//   Column("users.id") [aliased: true, qualified: true]
-	String() string
 }

--- a/internal/core/contract/renderable.go
+++ b/internal/core/contract/renderable.go
@@ -1,0 +1,87 @@
+// Package contract defines core interfaces and types for Entiqon tokens,
+// including rendering and error-handling abstractions. These interfaces live
+// in the “contracts” layer to decouple token implementations from dialects
+// and other build-time details.
+//
+// To regenerate documentation after coding sessions, use `godoc` or configure
+// your Go documentation generator (e.g., `go doc`, `pkgsite`, or `godoc -http=:6060`).
+package contract
+
+// Quoter is the minimal interface required to quote SQL identifiers according
+// to a specific SQL dialect. Any dialect implementation (Postgres, MySQL, etc.)
+// must implement this method to be used as a Quoter.
+//
+// Example implementation in a dialect (Postgres):
+//
+//	func (p *PostgresDialect) QuoteIdentifier(id string) string {
+//	    // Replace any internal double-quotes with two double-quotes:
+//	    escaped := strings.ReplaceAll(id, `"`, `""`)
+//	    return `"` + escaped + `"`
+//	}
+type Quoter interface {
+	// QuoteIdentifier wraps the given identifier (e.g., table name, column name)
+	// using the appropriate quoting mechanism for the dialect. Implementations
+	// should escape internal occurrences of the quote character if required.
+	//
+	// Example:
+	//   QuoteIdentifier("user")      → "\"user\""
+	//   QuoteIdentifier("user\"name") → "\"user\"\"name\""
+	QuoteIdentifier(id string) string
+}
+
+// Renderable defines the methods that any token-like entity should expose in order
+// to be rendered into SQL or used for diagnostics. By centralizing these four methods,
+// we ensure a uniform rendering strategy for tokens such as Column, Table, and Condition.
+//
+// Raw() and String() do not require any quoting, while RenderName and RenderAlias
+// accept a Quoter to apply dialect-specific quoting. If the Quoter argument is nil,
+// implementations must return unquoted results.
+type Renderable interface {
+	// Raw returns the token in its raw SQL form, for example:
+	//   - "users.id"           (no alias)
+	//   - "users.id AS u"      (with alias)
+	// If the receiver is nil, Raw must return an empty string.
+	//
+	// Raw does not apply any quoting; it simply reconstructs the original
+	// representation of Name and Alias, suitable for embedding in SQL
+	// without further transformation.
+	Raw() string
+
+	// RenderName returns the token’s identifier (alias if present, or name otherwise),
+	// applying quoting only if the provided Quoter is non-nil. If Quoter is nil,
+	// it returns the raw identifier (alias or name) without quotes. If the receiver
+	// is nil or its Name is empty, RenderName must return an empty string.
+	//
+	// For example, given a token with Name="id", Alias="user_id":
+	//   RenderName(q) with a Postgres Quoter → "\"user_id\""
+	//   RenderName(nil)                       → "user_id"
+	//
+	// Examples of use:
+	//   col := NewColumnToken("users.id", "u")
+	//   quoted := col.RenderName(postgresDialect) // => "\"u\""
+	//   plain  := col.RenderName(nil)            // => "u"
+	RenderName(q Quoter) string
+
+	// RenderAlias takes a fully-qualified identifier (qualified), and if the token has
+	// a non-empty Alias, returns a string of the form "qualified AS alias", quoting
+	// the alias if a Quoter is provided. If the token’s Alias is empty, or if the
+	// receiver is nil, RenderAlias must return the qualified string unchanged.
+	//
+	// For example, given a token with Alias="u" and qualified="\"users\".\"id\"":
+	//   RenderAlias(q) with a Postgres Quoter → "\"users\".\"id\" AS \"u\""
+	//   RenderAlias(nil)                        → "users.id AS u"
+	//   RenderAlias(any, "")                    → ""
+	RenderAlias(q Quoter, qualified string) string
+
+	// String returns a diagnostic or “pretty-print” representation of the token,
+	// including its Kind (if available), Name, and metadata such as whether it is
+	// aliased or errored. If the receiver is nil, String must return an empty string.
+	//
+	// Example output for a Column token (Kind=ColumnKind, Name="id", Alias="u", no error):
+	//   Column("id") [aliased: true, errored: false]
+	//
+	// If the token’s kind is UnknownKind, String should print “Unknown” as the kind.
+	//
+	// Since: v1.7.0
+	String() string
+}


### PR DESCRIPTION
- Renamed BaseToken field `source` to `input` (incl. GetSource → GetInput) to avoid naming conflicts with data sources
- Introduced `contract.Renderable` in internal/core/contracts/renderable.go, grouping Raw, RenderName, RenderAlias, and String methods
- Updated BaseToken (internal/build/token/base.go): • Adjusted RenderName and RenderAlias to accept `contract.Quoter` instead of `driver.Dialect` • Refactored Raw() and String() to satisfy `contract.Renderable` • Marked HasError() and SetErrorWith() as deprecated in favor of IsErrored() and SetError() • Added GoDoc “Since: v1.7.0” annotations on new/renamed methods • Renamed `source` field to `input` for diagnostics
- Updated unit tests (internal/build/token/base_test.go): • Adjusted calls to RenderName/RenderAlias to pass a Quoter • Covered Raw(), String(), GetInput(), and other renamed methods
- Added BaseToken developer guide (docs/developer/base_token.md) with implementation details, examples, and expected outputs