### PR TITLE
feat(number): extend ParseFrom to support bool values

### DIFF
--- a/common/number/parser.go
+++ b/common/number/parser.go
@@ -1,0 +1,78 @@
+// File: common/number/parser.go
+
+// Package number provides utilities for parsing numeric values from generic input types.
+package number
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// ParseFrom attempts to parse an integer value from an input of generic type.
+//
+// The input value can be any of the following types:
+//   - int, int8, int16, int32, int64
+//   - uint, uint8, uint16, uint32, uint64 (uint64 values are checked for overflow)
+//   - float32, float64 (fractional parts are truncated)
+//   - string (parsed using strconv.Atoi)
+//   - bool (false = 0, true = 1)
+//
+// If the input is a string, it will be parsed as a base-10 integer.
+// If the input is a numeric type, it will be converted to int.
+// If the input is a bool, false returns 0, true returns 1.
+// If the input type is unsupported or conversion fails, an error is returned.
+//
+// Note: Conversion from float will truncate the fractional part without rounding.
+//
+// Examples:
+//
+//	ParseFrom("123") => 123, nil
+//	ParseFrom(123.9) => 123, nil
+//	ParseFrom(true) => 1, nil
+//	ParseFrom(false) => 0, nil
+//
+// Returns the parsed integer or an error if parsing/conversion is not possible.
+func ParseFrom(value interface{}) (int, error) {
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int8:
+		return int(v), nil
+	case int16:
+		return int(v), nil
+	case int32:
+		return int(v), nil
+	case int64:
+		return int(v), nil
+	case uint:
+		return int(v), nil
+	case uint8:
+		return int(v), nil
+	case uint16:
+		return int(v), nil
+	case uint32:
+		return int(v), nil
+	case uint64:
+		if v > uint64(^uint(0)>>1) {
+			return 0, fmt.Errorf("uint64 value too large for int")
+		}
+		return int(v), nil
+	case float32:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case string:
+		i, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse string to int: %w", err)
+		}
+		return i, nil
+	case bool:
+		if v {
+			return 1, nil
+		}
+		return 0, nil
+	default:
+		return 0, fmt.Errorf("unsupported type %T for ParseFrom", value)
+	}
+}

--- a/common/number/parser_test.go
+++ b/common/number/parser_test.go
@@ -1,0 +1,63 @@
+// File: common/number/parser_test.go
+
+package number_test
+
+import (
+	"testing"
+
+	"github.com/entiqon/entiqon/common/number"
+)
+
+func TestParseFrom(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     interface{}
+		want      int
+		expectErr bool
+	}{
+		{"int", int(42), 42, false},
+		{"int8", int8(-12), -12, false},
+		{"int16", int16(1000), 1000, false},
+		{"int32", int32(123456), 123456, false},
+		{"int64", int64(-987654321), -987654321, false},
+
+		{"uint", uint(42), 42, false},
+		{"uint8", uint8(255), 255, false},
+		{"uint16", uint16(65535), 65535, false},
+		{"uint32", uint32(4294967295), 4294967295, false},
+
+		{"uint64Ranged", uint64(1 << 30), 1 << 30, false},
+		{"uint64Overflow", uint64(1 << 63), 0, true},
+
+		{"float32", float32(123.456), 123, false},
+		{"float64", -9876.54321, -9876, false},
+
+		{"StringValid", "12345", 12345, false},
+		{"StringNegative", "-42", -42, false},
+		{"StringInvalid", "12abc", 0, true},
+
+		{"BoolTrue", true, 1, false},
+		{"BoolFalse", false, 0, false},
+
+		{"UnsupportedTypeStruct", struct{}{}, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := number.ParseFrom(tt.input)
+			if tt.expectErr {
+				if err == nil {
+					t.Errorf("ParseFrom(%v) expected error but got nil", tt.input)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ParseFrom(%v) unexpected error: %v", tt.input, err)
+					return
+				}
+				if got != tt.want {
+					t.Errorf("ParseFrom(%v) = %d; want %d", tt.input, got, tt.want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Added support for boolean inputs in ParseFrom, converting `true` to 1 and `false` to 0.
- Updated GoDoc to document bool support and conversion behavior.
- Added unit tests covering boolean true/false cases.
- Maintained existing coverage for all numeric and string input types.
- Ensured no external testing libraries are used in tests.