### PR TITLE
feat(contract): add generic Cloanable interface and assert Field compliance

### DIFF
--- a/db/contract/clonable.go
+++ b/db/contract/clonable.go
@@ -1,0 +1,18 @@
+// File: db/contract/renderable.go
+
+// Package contract defines small, reusable behavioral contracts (interfaces)
+// that core tokens and builders can implement to enable polymorphic behavior
+// without tight coupling between packages.
+package contract
+
+// Cloanable is a generic contract for types that can produce a semantic clone
+// of themselves. The type parameter T is the concrete return type of Clone.
+//
+// Notes:
+//   - The name "Cloanable" is intentional per project conventions.
+//   - Implementations should return a deep or semantic clone suitable for
+//     independent mutation by callers.
+type Cloanable[T any] interface {
+	// Clone returns a new instance that is a semantic copy of the receiver.
+	Clone() T
+}

--- a/db/token/field.go
+++ b/db/token/field.go
@@ -22,6 +22,9 @@ import (
 // Ensure Field implements contract.Renderable at compile time.
 var _ contract.Renderable = (*Field)(nil)
 
+// Ensure Field implements contract.Cloanable[*Field] at compile time.
+var _ contract.Cloanable[*Field] = (*Field)(nil)
+
 // Field represents a column/field or expression in a SELECT clause.
 //
 // It holds the original user input, a parsed SQL expression (without alias),
@@ -65,6 +68,16 @@ func NewField(input string, expr string, alias string, isRaw bool) *Field {
 		fd.setError(errors.New("derived field name cannot be empty"))
 	}
 	return fd
+}
+
+// Clone returns a semantic copy of the Field. A nil receiver yields nil.
+// This nil-preserving behavior makes Clone safe to call unconditionally.
+func (f *Field) Clone() *Field {
+	if f == nil {
+		return nil
+	}
+	cp := *f
+	return &cp
 }
 
 // IsAliased reports whether the field has a non-empty alias.

--- a/db/token/field_test.go
+++ b/db/token/field_test.go
@@ -162,6 +162,27 @@ func TestColumn(t *testing.T) {
 	})
 
 	t.Run("Methods", func(t *testing.T) {
+		t.Run("Clone", func(t *testing.T) {
+			t.Run("Success", func(t *testing.T) {
+				orig := &token.Field{Input: "i", Expr: "e", Alias: "a", IsRaw: true}
+				cl := orig.Clone()
+				if cl == orig {
+					t.Fatal("expected different pointer")
+				}
+				if *cl != *orig {
+					t.Errorf("clone differs: got %+v, want %+v", *cl, *orig)
+				}
+			})
+
+			t.Run("NilReceiver", func(t *testing.T) {
+				var field *token.Field = nil
+				got := field.Clone()
+				if got != nil {
+					t.Errorf("cloned field = %+v, want %+v", got, field)
+				}
+			})
+		})
+
 		t.Run("IsAliased", func(t *testing.T) {
 			cases := []struct {
 				alias string


### PR DESCRIPTION
- Introduce contract.Cloanable[T] with Clone() T
- Add compile-time assertion for token.Field implementing Cloanable[*Field]
- Provide Field.Clone() for explicit duplication (factory stays non-cloning)