### PR TITLE
refactor(token): make Field constructor inputs deterministic with improved raw expression alias handling

### DIFF
--- a/db/token/field.go
+++ b/db/token/field.go
@@ -12,8 +12,11 @@
 package token
 
 import (
+	"crypto/sha1"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/entiqon/entiqon/db/contract"
@@ -55,18 +58,112 @@ type Field struct {
 // NewField constructs a Field from the given components, trimming the alias
 // and initializing a validation error when the expression is empty or when
 // a derived name would be empty.
-func NewField(input string, expr string, alias string, isRaw bool) *Field {
-	fd := &Field{
-		Input: input,
-		Expr:  expr,
-		Alias: strings.TrimSpace(alias),
-		IsRaw: isRaw,
+func NewField(inputs ...any) *Field {
+	if len(inputs) == 0 {
+		return &Field{}
 	}
-	if strings.TrimSpace(expr) == "" {
-		fd.setError(errors.New("expression cannot be empty"))
-	} else if fd.Name() == "" {
-		fd.setError(errors.New("derived field name cannot be empty"))
+
+	// Validate expr/input type
+	if err := validateType(inputs[0]); err != nil {
+		fd := &Field{}
+		if err.Error() == "input is a Field" {
+			fd.setError(fmt.Errorf("%s; if you want to create a copy, use Clone() instead", err.Error()))
+		} else {
+			fd.setError(err)
+		}
+		return fd
 	}
+	expr := strings.TrimSpace(inputs[0].(string))
+
+	switch len(inputs) {
+	case 3:
+		// input, alias, isRawExpr
+		if err := validateType(inputs[1]); err != nil {
+			fd := &Field{
+				Input: expr,
+			}
+			fd.setError(fmt.Errorf("%s: %s", err.Error(), "alias must be a string"))
+			return fd
+		}
+		alias := strings.TrimSpace(inputs[1].(string))
+
+		isRaw, ok := inputs[2].(bool)
+		if !ok {
+			fd := &Field{
+				Input: expr,
+			}
+			fd.setError(errors.New("isRaw must be a bool"))
+			return fd
+		}
+
+		return &Field{
+			Input: expr,
+			Expr:  expr,
+			Alias: alias,
+			IsRaw: isRaw,
+		}
+
+	case 2:
+		// expr, alias
+		if err := validateType(inputs[1]); err != nil {
+			fd := &Field{}
+			fd.setError(err)
+			return fd
+		}
+		alias := strings.TrimSpace(inputs[1].(string))
+		return &Field{
+			Input: expr,
+			Expr:  expr,
+			Alias: alias,
+			IsRaw: isRawExpr(expr),
+		}
+
+	case 1:
+		isRaw := isRawExpr(expr)
+
+		if isRaw {
+			parsedExpr := expr // always preserve full expression
+
+			// Explicit AS → parse alias
+			if strings.Contains(strings.ToUpper(expr), " AS ") {
+				_, parsedAlias, _ := parseAlias(expr)
+				return &Field{
+					Input: expr,
+					Expr:  parsedExpr,
+					Alias: parsedAlias,
+					IsRaw: true,
+				}
+			}
+
+			// Has space but no AS → error (alias without AS is invalid for raw)
+			if HasTrailingAliasWithoutAS(expr) {
+				fd := &Field{Input: parsedExpr}
+				fd.setError(errors.New("raw expressions must use explicit AS for alias"))
+				return fd
+			}
+
+			// No alias at all → auto-generate
+			auto := autoAlias(parsedExpr)
+			return &Field{
+				Input: fmt.Sprintf("%s AS %s", parsedExpr, auto),
+				Expr:  parsedExpr,
+				Alias: auto,
+				IsRaw: true,
+			}
+		}
+
+		// Not raw — safe to parse normally
+		parsedExpr, parsedAlias, _ := parseAlias(expr)
+		return &Field{
+			Input: expr,
+			Expr:  parsedExpr,
+			Alias: parsedAlias,
+			IsRaw: false,
+		}
+	}
+
+	fd := &Field{}
+	fd.setError(errors.New("invalid NewField signature"))
 	return fd
 }
 
@@ -109,7 +206,7 @@ func (f *Field) IsValid() bool {
 
 // Name returns a stable identifier for the field.
 //
-// If Alias is set, it returns the lower-cased alias. Otherwise it derives
+// If Alias is set, it returns the lower-cased alias. Otherwise, it derives
 // a name from Expr by removing non-alphanumeric characters and lower-casing.
 func (f *Field) Name() string {
 	if f.Alias != "" {
@@ -147,7 +244,14 @@ func (f *Field) String() string {
 		icon = "⛔️"
 	}
 
-	base := fmt.Sprintf("%s Field(%q) [alias: %t, errored: %t]", icon, f.Name(), aliased, errored)
+	base := fmt.Sprintf(
+		"%s Field(%q) [raw: %t, aliased: %t, errored: %t]",
+		icon,
+		f.Name(),
+		f.IsRaw,
+		aliased,
+		errored,
+	)
 	if errored && f.Error != nil {
 		return base + " – " + f.Error.Error()
 	}
@@ -170,3 +274,89 @@ func deriveNameFromExpr(expr string) string {
 // setError assigns an error to the field. Intended for use during
 // construction/parsing to capture validation failures.
 func (f *Field) setError(err error) { f.Error = err }
+
+func autoAlias(expr string) string {
+	const prefix = "raw_expr_"
+	h := sha1.New()
+	h.Write([]byte(expr))
+	sum := hex.EncodeToString(h.Sum(nil))
+	return prefix + sum[:6] // 6 hex chars => ~16.7 million combinations
+}
+
+// HasTrailingAliasWithoutAS checks if the last space-separated token is an alias candidate
+func HasTrailingAliasWithoutAS(expr string) bool {
+	up := strings.ToUpper(expr)
+	if strings.Contains(up, " AS ") {
+		return false // explicit AS → fine
+	}
+
+	tokens := strings.Fields(expr)
+	if len(tokens) <= 1 {
+		return false // single token can't have alias
+	}
+
+	last := tokens[len(tokens)-1]
+	penultimate := tokens[len(tokens)-2]
+
+	// If the token before last is an operator, this "last" is part of the expression, not alias
+	operators := map[string]bool{"||": true, "+": true, "-": true, "*": true, "/": true}
+	if operators[penultimate] {
+		return false
+	}
+
+	// Otherwise, if it looks like an identifier → treat as alias
+	if regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`).MatchString(last) {
+		return true
+	}
+	return false
+}
+
+// isRawExpr detects whether the expression contains raw SQL indicators.
+func isRawExpr(expr string) bool {
+	expr = strings.TrimSpace(expr)
+
+	// Parentheses usually indicate a raw expression (function call, grouping)
+	if strings.ContainsAny(expr, "()") {
+		return true
+	}
+
+	// Common SQL arithmetic or concatenation operators
+	operators := []string{"||", "+", "-", "*", "/"}
+	for _, op := range operators {
+		if strings.Contains(expr, op) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func parseAlias(s string) (expr, alias string, fromAS bool) {
+	s = strings.TrimSpace(s)
+
+	// Try explicit AS first (case-insensitive)
+	re := regexp.MustCompile(`(?i)\s+AS\s+`)
+	parts := re.Split(s, 2)
+	if len(parts) == 2 {
+		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), true
+	}
+
+	// Fallback: split by first space
+	parts = strings.Fields(s)
+	if len(parts) >= 2 {
+		return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), false
+	}
+
+	return s, "", false
+}
+
+func validateType(input any) error {
+	switch v := input.(type) {
+	case Field, *Field:
+		return errors.New("input is a Field")
+	case string:
+		return nil
+	default:
+		return fmt.Errorf("unsupported type: %T", v)
+	}
+}


### PR DESCRIPTION
- Defined strict NewField input contract: • inputs[0]: expression to analyze for inline alias via AS or space • inputs[1]: optional alias (string only, no raw-expression resolution in 2-arg form) • inputs[2]: optional IsRaw (bool only, taken as-is in 3-arg form)
- For raw expressions: • Accept alias only with explicit AS • Reject space-based alias without AS • Auto-generate alias as raw_expr_<6hex> if none provided
- For non-raw expressions: • Accept alias via AS or space • Leave alias empty if none provided
- Refactored token.HasTrailingAliasWithoutAS to avoid false positives in complex expressions
- Added branch-complete tests covering: • Explicit AS • Single token • Operator before last token • Alias without AS • Non-identifier last token
- Achieves 100% branch coverage for token.HasTrailingAliasWithoutAS