### PR TITLE
docs(release): add v1.11.0 changelog, release notes, and site updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.11.0](https://github.com/entiqon/entiqon/releases/tag/v1.11.0) - 2025-08-17
+
+### Highlights
+
+-   **New parsing façade**: one-line helpers for `Boolean`, `Float`,
+    `Decimal`, and `Date`.
+-   **Deterministic date cleaning**: `CleanAndParse`,
+    `CleanAndParseAsString`, strict `YYYYMMDD` prefix path, and 100%
+    tests.
+-   **Boolean parser++**: extended tokens (`on/off`, `y/n`, `t/f`) and
+    explicit `nil` rejection.
+-   **SQL Builder/Token overhaul**: `Column → Field`, `FieldCollection`,
+    deterministic `NewField` inputs, and Postgres/Base dialects with
+    tests.
+
 ## [v1.10.0](https://github.com/entiqon/entiqon/releases/tag/v1.10.1) - 2025-08-07
 
 - dce6cf7 feat(object): enhance Exists, GetValue, SetValue with flexible types; add extensive tests; update docs (Isidro Lopez)

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@
 
 ## 📦 Releases
 
+- [v1.11.0](./releases/release-notes-v1.11.0.md)
 - [v1.10.0](./releases/release-notes-v1.10.0.md)
-- [v1.9.0](./releases/release-notes-v1.9.0.md)
 - [CHANGELOG](./CHANGELOG.md)
 
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -48,7 +48,7 @@ coverage and modular design.
 ## 📦 Releases
 
 - [Overview](./releases/index.md)
-- [v1.7.0 - Forge](./releases/release-notes-v1.7.0.md)
+- [v1.11.0 - Forge](./releases/release-notes-v1.11.0.md)
 - [Full Changelog](./CHANGELOG.md)
 
 ---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,7 +42,7 @@ nav:
 
   - 📦 Releases:
       - Overview: releases/index.md
-      - Lastest: releases/release-notes-v1.10.0.md
+      - Lastest: releases/release-notes-v1.11.0.md
       - Full Changelog: CHANGELOG.md
 
 markdown_extensions:

--- a/releases/index.md
+++ b/releases/index.md
@@ -6,6 +6,7 @@ Welcome to the complete history of Entiqon SQL Builder releases.
 
 ## 📦 Versions
 
+- [v1.11.0](release-notes-v1.11.0.md)
 - [v1.10.0](release-notes-v1.10.0.md)
 - [v1.9.0](release-notes-v1.9.0.md)
 - [v1.8.3](release-notes-v1.8.3.md)

--- a/releases/release-notes-v1.10.0.md
+++ b/releases/release-notes-v1.10.0.md
@@ -1,5 +1,5 @@
 
-# Release vX.Y.Z — Object Package Enhancements and Test Improvements
+# Release v1.10.0 — Object Package Enhancements and Test Improvements
 
 ## Highlights
 

--- a/releases/release-notes-v1.11.0.md
+++ b/releases/release-notes-v1.11.0.md
@@ -1,0 +1,86 @@
+# v1.11.0 --- Parsing shortcuts, deterministic date cleaning, and SQL token upgrades
+
+## Highlights
+
+-   **New parsing façade**: one-line helpers for `Boolean`, `Float`,
+    `Decimal`, and `Date`.
+-   **Deterministic date cleaning**: `CleanAndParse`,
+    `CleanAndParseAsString`, strict `YYYYMMDD` prefix path, and 100%
+    tests.
+-   **Boolean parser++**: extended tokens (`on/off`, `y/n`, `t/f`) and
+    explicit `nil` rejection.
+-   **SQL Builder/Token overhaul**: `Column → Field`, `FieldCollection`,
+    deterministic `NewField` inputs, and Postgres/Base dialects with
+    tests.
+
+------------------------------------------------------------------------
+
+## What changed since v1.10.0
+
+### ✨ Features
+
+-   **common/extension**
+    -   `b720f7f` feat: add parser shortcuts for **Boolean**, **Float**,
+        **Decimal**, **Date**
+-   **common/date**
+    -   `dd173da` feat: introduce **Cleaning**, **ParseAndFormat**, and
+        **ParseFrom** with full coverage
+-   **contract / token / builder / dialect**
+    -   `b2b47ca` feat(contract): add generic **Cloanable** interface;
+        assert `Field` compliance
+    -   `d140010` feat(token): **FieldCollection** with full ops + tests
+    -   `d4c0905` feat(token): implement **Column.Render** and satisfy
+        `Renderable` with tests
+    -   `2ce91f1` feat(token): initial **Column** token with full unit
+        tests
+    -   `ca22e45` feat(builder): first basic **select** builder
+    -   `ccdb48f` feat(dialect): **PostgresDialect** with PG-specific
+        syntax + tests
+    -   `ff00ca6` feat(dialect): **BaseDialect** baseline implementation
+
+### ♻️ Refactors
+
+-   `f45ff2a` refactor(common): rename **math package → extension**
+-   `c8ca52f` refactor(token): make **Field** constructor inputs
+    deterministic; improved raw-alias handling
+-   `45da5dc` refactor(token): **rename Column → Field** and add tests
+-   `9fc782f` refactor(builder): improve `builder.Select`, delegate
+    field resolution to `token.Field`, add `select.GetFields()`
+-   `e722fdc` refactor(builder): move `builder` to **internal/builder**
+
+### 🛠️ Fixes
+
+-   `3aabe8c` fix(entiqon): update real project logo
+
+### 📚 Docs
+
+-   `9907b5c` docs(contract): full **GoDoc** for `Renderable`
+-   `7f94040` docs(entiqon): update real project logo & disposition
+
+------------------------------------------------------------------------
+
+## Breaking / Migration notes
+
+-   **math** → **extension** package rename
+-   **token.Column** → **token.Field**
+-   `builder.Select` changes: use `select.Fields(...)` and
+    `select.GetFields()`
+-   Date parsing: use `CleanAndParse` with options, or
+    `StrictYYYYMMDDOptions()` for strict feeds
+
+------------------------------------------------------------------------
+
+## Test coverage highlights
+
+-   Full coverage for `CleanAndParse`, `CleanAndParseAsString`,
+    `ParseFrom`
+-   Boolean parser extended token cases covered
+-   Field, FieldCollection, Dialects fully unit-tested
+
+------------------------------------------------------------------------
+
+## Upgrade checklist
+
+-   Update imports: `common/math/...` → `common/extension/...`
+-   Replace `token.Column` with `token.Field`
+-   For date parsing: switch to `CleanAndParse` or strict options


### PR DESCRIPTION
- Add CHANGELOG entry for v1.11.0: • Parsing shortcuts for Boolean, Float, Decimal, Date • Deterministic date cleaning (CleanAndParse, CleanAndParseAsString, strict YYYYMMDD prefix) • Boolean parser extended tokens and nil validation • SQL builder/token/dialect enhancements (Column→Field, FieldCollection, Base/Postgres dialects) • Package rename: math → extension
- Add standalone v1.11.0 release notes file for GitHub releases
- Update documentation site with new parsing shortcuts and migration notes
- Ensure consistency across CHANGELOG, release notes, and site docs