### PR TITLE
feat(token/field): add Debug() and enhance String() with ✅/⛔️ diagnostics

### DIFF
--- a/db/builder/select.go
+++ b/db/builder/select.go
@@ -122,7 +122,6 @@ func (b *SelectBuilder) Build() (string, error) {
 
 	parts := make([]string, 0, b.fields.Length())
 	var bad []string
-
 	for _, field := range b.fields.Items() {
 		if field.IsErrored() {
 			bad = append(bad,
@@ -131,7 +130,6 @@ func (b *SelectBuilder) Build() (string, error) {
 		}
 		parts = append(parts, field.Render())
 	}
-
 	if len(bad) > 0 {
 		return "", fmt.Errorf("❌ [Build] - Invalid fields:\n\t%s", strings.Join(bad, "\n\t"))
 	}

--- a/db/token/doc.go
+++ b/db/token/doc.go
@@ -1,0 +1,70 @@
+// Package token defines the low-level primitives used by the SQL builder.
+//
+// # Overview
+//
+// The token package provides fundamental structures to represent SQL query
+// fragments in a dialect-agnostic way. These tokens are consumed by higher-
+// level builders (e.g. SelectBuilder) to construct safe SQL statements.
+//
+// The primary type in this package is Field, which models a column or
+// expression in a SELECT clause.
+//
+// # Field
+//
+// A Field represents a single column or expression in a SELECT query.
+// It can optionally have an alias and may be marked as raw.
+//
+// Field supports multiple instantiation forms through NewField:
+//
+//   - NewField("expr")
+//     A single expression, e.g. "id"
+//
+//   - NewField("expr alias")
+//     Expression with alias, parsed by space, e.g. "id user_id"
+//
+//   - NewField("expr AS alias")
+//     Expression with alias using AS, e.g. "id AS user_id"
+//
+//   - NewField("expr", "alias")
+//     Expression and alias provided separately
+//
+//   - NewField("expr", "alias", true)
+//     Expression and alias with IsRaw set explicitly
+//
+//   - NewField(*Field)
+//     Disallowed: users must call Clone() instead
+//
+// # Field Behavior
+//
+// A Field consists of:
+//   - Input: the raw user input
+//   - Expr: the resolved expression (e.g. "id")
+//   - Alias: the optional alias (e.g. "user_id")
+//   - IsRaw: whether this is a raw expression
+//   - Error: set if construction fails
+//
+// Methods include:
+//   - Render: returns a dialect-agnostic SQL fragment
+//   - Clone: produces a deep copy
+//   - IsAliased, IsErrored, IsValid: convenience checks
+//
+// # Usage Example
+//
+// Select specific columns:
+//
+//	sb := builder.NewSelect(nil).
+//	    Fields("id", "name").
+//	    Source("users")
+//
+//	sql, _ := sb.Build()
+//	// SELECT id, name FROM users
+//
+// Add aliases:
+//
+//	sb := builder.NewSelect(nil).
+//	    Fields("id user_id", "COUNT(*) total").
+//	    Source("users")
+//
+//	sql, _ := sb.Build()
+//	// SELECT id AS user_id, COUNT(*) AS total FROM users
+package token

--- a/db/token/example_test.go
+++ b/db/token/example_test.go
@@ -1,0 +1,79 @@
+package token_test
+
+import (
+	"fmt"
+
+	"github.com/entiqon/entiqon/db/token"
+)
+
+// ExampleNewField demonstrates the basic instantiation forms of Field.
+func ExampleNewField() {
+	// Single expression
+	f1 := token.NewField("id")
+
+	// Expression with alias (space-separated)
+	f2 := token.NewField("id user_id")
+
+	// Expression with alias (AS keyword)
+	f3 := token.NewField("COUNT(*) AS total")
+
+	// Expression and alias separately
+	f4 := token.NewField("name", "username")
+
+	// Expression and alias with raw flag
+	f5 := token.NewField("JSON_EXTRACT(data, '$.name')", "extracted", true)
+
+	fmt.Println(f1.Render())
+	fmt.Println(f2.Render())
+	fmt.Println(f3.Render())
+	fmt.Println(f4.Render())
+	fmt.Println(f5.Render())
+
+	// Output:
+	// id
+	// id AS user_id
+	// COUNT(*) AS total
+	// name AS username
+	// JSON_EXTRACT(data, '$.name') AS extracted
+}
+
+// ExampleField_clone demonstrates the Clone method.
+func ExampleField_clone() {
+	original := token.NewField("id", "user_id")
+	clone := original.Clone()
+
+	fmt.Println(original.Render())
+	fmt.Println(clone.Render())
+	fmt.Println(original == clone) // should be false, deep copy
+
+	// Output:
+	// id AS user_id
+	// id AS user_id
+	// false
+}
+
+// ExampleField_invalid demonstrates invalid field creation.
+func ExampleField_invalid() {
+	// Passing an unsupported type (e.g. bool) results in an errored field.
+	f := token.NewField(true)
+
+	if f.IsErrored() {
+		fmt.Println(f.String()) // concise log view
+		fmt.Println(f.Debug())  // detailed diagnostic view
+	}
+
+	// Output:
+	// ⛔️ Field("true"): input type unsupported: bool
+	// ⛔️ Field("true"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
+}
+
+// ExampleField_debug demonstrates valid fields with Debug output.
+func ExampleField_debug() {
+	f := token.NewField("COUNT(*) AS total")
+	fmt.Println(f.String())
+	fmt.Println(f.Debug())
+
+	// Output:
+	// ✅ Field("COUNT(*) AS total")
+	// ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
+}

--- a/db/token/field.md
+++ b/db/token/field.md
@@ -1,0 +1,144 @@
+<h1 align="left">
+  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96"> token.Field
+</h1>
+<h6 align="left">Part of the <a href="https://github.com/entiqon/entiqon">Entiqon</a>::<span>Database</span> toolkit.</h6>
+
+
+## 📜 User Guide
+
+`token.Field` represents a **single column or expression** in a `SELECT` statement.  
+The builder provides multiple ways to instantiate it, depending on what you want to express.
+
+### Instantiation Rules
+
+1. **Single string** → one or more fields
+   - **Plain column**
+     ```go
+     .Fields("id")
+     // SELECT id
+     ```
+   - **Comma-separated list**
+     ```go
+     .Fields("id, name, email")
+     // SELECT id, name, email
+     ```
+   - **Aliased by space**
+     ```go
+     .Fields("id user_id")
+     // SELECT id AS user_id
+     ```
+   - **Aliased by AS keyword**
+     ```go
+     .Fields("id AS user_id")
+     // SELECT id AS user_id
+     ```
+   - **Function expression with alias**
+     ```go
+     .Fields("COUNT(id) AS row_count")
+     // SELECT COUNT(id) AS row_count
+     ```
+
+2. **Two arguments (string, string)** → field + alias
+   ```go
+   .Fields("id", "user_id")
+   // SELECT id AS user_id
+   ```
+
+3. **Three arguments (string, string, bool)** → raw expression with alias
+   ```go
+   .Fields("COUNT(*)", "total", true)
+   // SELECT COUNT(*) AS total
+   ```
+
+4. **Multiple `Field` objects** → explicit choice
+   ```go
+   .Fields(
+       *token.NewField("id"),
+       *token.NewField("name"),
+   )
+   // SELECT id, name
+   ```
+
+### Things to Avoid
+
+- Don’t pass `("id", "name")` unless you mean **alias** (`id AS name`).  
+- Don’t try to concatenate raw SQL strings directly into `Fields` with multiple arguments unless you mean aliasing.  
+- Prefer explicit `token.NewField(...)` if you want to avoid ambiguity.
+
+---
+
+## 📚 Developer Guide
+
+### Internal Representation
+
+A `Field` has the following structure:
+
+```go
+type Field struct {
+    Input  string  // raw input as given by user
+    Expr   string  // resolved expression (alias stripped)
+    Alias  string  // optional alias
+    IsRaw  bool    // true if raw expression
+    Error  error   // set if instantiation failed
+}
+```
+
+### Lifecycle
+
+1. **Construction**  
+   - Always done through `token.NewField(...)`.  
+   - Handles all valid instantiation forms:
+     - `NewField("expr")`
+     - `NewField("expr alias")` or `NewField("expr AS alias")`
+     - `NewField("expr", "alias")`
+     - `NewField("expr", "alias", true)`
+     - `NewField(*Field)` (not allowed, use `.Clone()` instead)
+
+2. **Validation**  
+   - If input type is unsupported, `Error` is set.  
+   - If input is another `Field`, `Error` advises to use `.Clone()` instead.  
+
+3. **Rendering**  
+   - `Render()` → dialect-agnostic SQL fragment.  
+   - `IsAliased()` → true if alias is set.  
+   - `IsErrored()` → true if `Error` is non-nil.  
+   - `IsValid()` → true if no error and Expr is set.  
+
+4. **Cloning**  
+   - `Clone()` returns a deep copy, preserving `nil` if original is nil.  
+   - Prevents mutation of shared fields.
+
+---
+
+## 🐞 Debugging and Logging
+
+Two methods are provided for inspection:
+
+- **`String()`** → concise log view.  
+  - ✅ valid field:  
+    ```
+    ✅ Field("id")
+    ✅ Field("id AS user_id")
+    ```
+  - ⛔️ invalid field:  
+    ```
+    ⛔️ Field("true"): input type unsupported: bool
+    ⛔️ Field(<nil>): wrong initialization
+    ```
+
+- **`Debug()`** → detailed diagnostic view.  
+  - ✅ valid field:  
+    ```
+    ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
+    ```
+  - ⛔️ invalid field:  
+    ```
+    ⛔️ Field("false"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
+    ```
+
+---
+
+## ✅ Summary
+
+- **Users**: treat `Field` as *one column or expression*. Use `.Fields(...)` safely with the instantiation rules.  
+- **Contributors**: enforce immutability, strict parsing in `NewField`, and clear reporting through `String()` and `Debug()`.

--- a/db/token/field_test.go
+++ b/db/token/field_test.go
@@ -379,7 +379,7 @@ func TestField(t *testing.T) {
 			}
 			f.Alias = "Alias"
 			got = f.String()
-			if !strings.Contains(got, "aliased: true") {
+			if !strings.Contains(got, "field AS Alias") {
 				t.Errorf("String() with alias got %q, want alias: true", got)
 			}
 			f.Error = errors.New("some error")


### PR DESCRIPTION
- Introduce Field.Debug() for compact diagnostic output:
  ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
  ⛔️ Field("true"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
- Update Field.String() to include ✅/⛔️ icons and handle wrong initialization explicitly
- Extend example_test.go with demonstrations of String() and Debug() for valid and invalid fields
- Revise field.md guide to document new String()/Debug() behavior with examples