### PR TITLE
feat(db/builder/select, token/field): add WHERE/AND/OR support and field diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.13.0](https://github.com/entiqon/entiqon/releases/tag/v1.13.0) - 2025-08-23
+
+### ✨ Features
+- **token/field**: add `Debug()` for compact diagnostics and enhance `String()` with ✅/⛔️ icons
+- **db/builder/select**: improve error reporting for invalid usage (clearer messages for unsupported inputs, missing sources, etc.)
+- **common/extension/integer**: introduce integer parser with full tests, examples, and parser shortcuts
+
+### 🧪 Tests
+- **builder/select**: reach 100% coverage for `SelectBuilder`
+
+### 🛠 Internal
+- **gench utility**: add `gench` bash tool to automate changelog entry generation
+
 ## [v1.12.0](https://github.com/entiqon/entiqon/releases/tag/v1.12.0) - 2025-08-22
 
 ### Highlights

--- a/Dockerfile-documentation
+++ b/Dockerfile-documentation
@@ -20,6 +20,8 @@ COPY common/extension/number/README.md     docs/packages/common/extension/number
 COPY common/extension/object/README.md     docs/packages/common/extension/object.md
 COPY common/extension/collection/README.md docs/packages/common/extension/collection.md
 COPY db/README.md                          docs/packages/db/overview.md
+COPY db/builder/README.md                  docs/packages/db/builder/overview.md
+COPY db/token/field.md                     docs/packages/db/token/field.md
 COPY releases/ docs/releases/
 RUN echo "Documentation content copied"
 

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -68,3 +68,44 @@ func ExampleSelectBuilder_invalidFields() {
 	//	⛔️ Field("false"): input type unsupported: bool
 	//	⛔️ Field("123"): input type unsupported: int
 }
+
+func ExampleSelectBuilder_where() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("id, name").
+		Source("users").
+		Where("age > 18", "status = 'active'").
+		Build()
+
+	fmt.Println(sql)
+	// Output:
+	// SELECT id, name FROM users WHERE age > 18 AND status = 'active'
+}
+
+func ExampleSelectBuilder_andOr() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("id").
+		Source("users").
+		Where("age > 18").
+		And("status = 'active'").
+		Or("role = 'admin'").
+		And("country = 'US'").
+		Build()
+
+	fmt.Println(sql)
+	// Output:
+	// SELECT id FROM users WHERE age > 18 AND status = 'active' OR role = 'admin' AND country = 'US'
+}
+
+func ExampleSelectBuilder_whereReset() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("id").
+		Source("users").
+		Where("age > 18").
+		And("status = 'active'").
+		Where("role = 'admin'"). // resets previous conditions
+		Build()
+
+	fmt.Println(sql)
+	// Output:
+	// SELECT id FROM users WHERE role = 'admin'
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,12 @@ nav:
               - Integer: packages/common/extension/integer.md
               - Number: packages/common/extension/number.md
               - Object: packages/common/extension/object.md
-      - Database: packages/db/overview.md
+      - Database:
+          - Overview: packages/db/overview.md
+          - Builders:
+              - Select: packages/db/builder/overview.md
+          - Tokens:
+              Field: packages/db/token/field.md
 
   - 📘 Architecture:
       - Builder Overview: dev/builder/builder_guide.md
@@ -44,16 +49,9 @@ nav:
       - Dialect: dev/driver/dialect.md
       - Styling: dev/driver/styling.md
 
-  - 🧱 Builders:
-      - SelectBuilder: dev/builder/select_builder.md
-      - InsertBuilder: dev/builder/insert_builder.md
-      - UpdateBuilder: dev/builder/update_builder.md
-      - DeleteBuilder: dev/builder/delete_builder.md
-      - UpsertBuilder: dev/builder/upsert_builder.md
-
   - 📦 Releases:
       - Overview: releases/index.md
-      - Lastest: releases/release-notes-v1.11.0.md
+      - Lastest: releases/release-notes-v1.13.0.md
       - Full Changelog: CHANGELOG.md
 
 markdown_extensions:

--- a/releases/index.md
+++ b/releases/index.md
@@ -6,6 +6,7 @@ Welcome to the complete history of Entiqon SQL Builder releases.
 
 ## 📦 Versions
 
+- [v1.13.0](release-notes-v1.13.0.md)
 - [v1.12.0](release-notes-v1.12.0.md)
 - [v1.11.0](release-notes-v1.11.0.md)
 - [v1.10.0](release-notes-v1.10.0.md)

--- a/releases/release-notes-v1.13.0.md
+++ b/releases/release-notes-v1.13.0.md
@@ -1,0 +1,47 @@
+# Release v1.13.0 — Builder Conditions & Field Diagnostics
+
+## 🚀 Features
+
+- **db/builder/select**
+  - Introduced `Where()`, `And()`, and `Or()` methods for building `WHERE` clauses
+  - Normalization of multiple conditions:  
+    `Where("a", "b")` → `WHERE a AND b`
+  - `Where()` clears existing conditions (like `Fields()`), while `And()`/`Or()` append
+  - Defensive handling of manual initialization (`&SelectBuilder{}`)
+  - Simplified `Build()` logic for condition rendering
+
+- **token/field**
+  - Added `Debug()` for compact diagnostic output:  
+    `✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]`  
+    `⛔️ Field("true"): [raw: false, aliased: false, errored: true] – input type unsupported: bool`
+  - Enhanced `String()` with ✅/⛔️ icons and explicit *wrong initialization* handling
+
+## 🧪 Tests
+
+- 100% coverage for `SelectBuilder` and `token.Field`
+- Added test cases for:
+  - Defaults, single/multiple conditions, ignore empty
+  - `Where` reset behavior
+  - `And`/`Or` appends
+  - Edge case: mixed `AND` + `OR`
+  - Manual initialization (`&SelectBuilder{}`)
+
+## 📖 Documentation
+
+- Updated `doc.go` for `builder` with conditions section
+- Added new `example_test.go` examples covering `Where`, `And`, `Or`, and reset semantics
+- Updated `field.md` guide with new `String()`/`Debug()` documentation
+- Updated `README.md` with:
+  - Strict **Field Rules**
+  - Examples of `Where`/`And`/`Or`
+  - Debugging output (`String()`/`Debug()`)
+  - Revised error cases
+  - Updated Status section
+
+---
+
+## 📄 Summary
+
+This release introduces **full WHERE clause support** with `Where`/`And`/`Or` methods,  
+improves **diagnostics for fields** with ✅/⛔️ outputs, and ensures **100% test coverage**.  
+All docs (README, guides, examples) have been updated accordingly.


### PR DESCRIPTION
- SelectBuilder:
  - Introduce Where(), And(), and Or() methods using collection.Collection[string]
  - Where() resets conditions; And()/Or() append
  - Normalize multiple conditions in a single call (e.g., Where("a","b") → a AND b)
  - Build() simplified to join stored conditions directly
  - Defensive handling for manual initialization (&SelectBuilder{}) with tests
  - Full test suite: defaults, single/multiple conditions, ignore empty, reset, append, OR first, AND first, mixed AND/OR, and manual init

- Field:
  - Add Debug() for compact diagnostic output with ✅/⛔️ icons and flags
  - Enhance String() with ✅/⛔️ icons and explicit "wrong initialization"
  - Update example_test.go with Debug()/String() usage
  - Update field.md guide documenting new behavior

Result: 100% coverage for builder.SelectBuilder and token.Field