### PR TITLE
feat(builder): add ORDER BY support with OrderBy/ThenOrderBy

### DIFF
--- a/db/builder/README.md
+++ b/db/builder/README.md
@@ -15,6 +15,7 @@ It is designed to be **simple**, **strict**, and **dialect-aware**.
   - Fields (`Fields`, `AddFields`) with strict rules
   - Source (`Source`)
   - Conditions (`Where`, `And`, `Or`)
+  - Ordering (`OrderBy`, `ThenOrderBy`)
   - Pagination (`Limit`, `Offset`)
   - SQL rendering (`Build`, `String`)
 - Default fallback to `SELECT *` if no fields are specified.
@@ -78,7 +79,7 @@ You can build `WHERE` clauses using `Where`, `And`, and `Or`:
 
 ```go
 sql, _ := builder.NewSelect(nil).
-    Fields("id", "name").
+    Fields("id, name").
     Source("users").
     Where("age > 18", "status = 'active'"). // normalized with AND
     Or("role = 'admin'").
@@ -94,6 +95,29 @@ Rules:
 - `And` appends with `AND`.
 - `Or` appends with `OR`.
 - Multiple conditions in one `Where(...)` are normalized with `AND`.
+
+---
+
+### Ordering
+
+You can build `ORDER BY` clauses using `OrderBy` and `ThenOrderBy`:
+
+```go
+sql, _ := builder.NewSelect(nil).
+    Fields("id, name").
+    Source("users").
+    OrderBy("created_at DESC").
+    ThenOrderBy("id ASC").
+    Build()
+
+fmt.Println(sql)
+// Output: SELECT id, name FROM users ORDER BY created_at DESC, id ASC
+```
+
+Rules:
+- `OrderBy` resets ordering (like `Fields`).
+- `ThenOrderBy` appends additional fields.
+- Empty or whitespace values are ignored.
 
 ---
 
@@ -154,12 +178,12 @@ Currently, supports:
 - Field selection and aliasing (strict rules enforced)
 - Single source
 - WHERE conditions with AND/OR composition
+- ORDER BY with multiple fields
 - Limit and offset
 - Error reporting for invalid fields with ✅/⛔️ diagnostics
 
 Planned extensions include:
 - Joins
-- Ordering
 - Grouping
 - Parameter binding
 

--- a/db/builder/doc.go
+++ b/db/builder/doc.go
@@ -1,8 +1,8 @@
 // Package builder provides a fluent API to construct SQL SELECT queries.
 //
 // The SelectBuilder type allows incremental composition of SELECT statements
-// with support for fields, sources, conditions, limits, and offsets. It is
-// simple, extensible, and dialect-aware.
+// with support for fields, sources, conditions, ordering, limits, and offsets.
+// It is simple, extensible, and dialect-aware.
 //
 // # Overview
 //
@@ -19,12 +19,14 @@
 //
 // # Methods
 //
-//   - Fields(...interface{}): reset and set fields for the select clause.
+//   - Fields(...interface{}): reset and set fields for the SELECT clause.
 //   - AddFields(...interface{}): append fields without resetting.
 //   - Source(string): set the source table.
 //   - Where(...string): reset and set conditions for the WHERE clause.
 //   - And(...string): append conditions with AND.
 //   - Or(...string): append conditions with OR.
+//   - OrderBy(...string): reset and set fields for the ORDER BY clause.
+//   - ThenOrderBy(...string): append additional ORDER BY fields.
 //   - Limit(int): apply LIMIT.
 //   - Offset(int): apply OFFSET.
 //   - Build(): construct the SQL string or return an error.
@@ -43,7 +45,7 @@
 //
 // # Conditions
 //
-// Conditions are expressed as raw strings. They are combined as follows:
+// Are expressed as raw strings. They are combined as follows:
 //
 //   - Where() clears existing conditions and sets new ones.
 //   - And() appends conditions joined by AND.
@@ -53,7 +55,7 @@
 // For example:
 //
 //	sb := builder.NewSelect(nil).
-//		Fields("id", "name").
+//		Fields("id, name").
 //		Source("users").
 //		Where("age > 18", "status = 'active'").
 //		Or("role = 'admin'").
@@ -61,6 +63,25 @@
 //
 //	sql, _ := sb.Build()
 //	// SELECT id, name FROM users WHERE age > 18 AND status = 'active' OR role = 'admin' AND country = 'US'
+//
+// # Ordering
+//
+// Ordering is expressed as raw strings (e.g. "created_at DESC"). They are combined as follows:
+//
+//   - OrderBy() clears existing ordering and sets new ones.
+//   - ThenOrderBy() appends additional ORDER BY fields.
+//   - Empty or whitespace-only strings are ignored.
+//
+// For example:
+//
+//	sb := builder.NewSelect(nil).
+//		Fields("id, name").
+//		Source("users").
+//		OrderBy("created_at DESC").
+//		ThenOrderBy("id ASC")
+//
+//	sql, _ := sb.Build()
+//	// SELECT id, name FROM users ORDER BY created_at DESC, id ASC
 //
 // # Error Handling
 //
@@ -75,13 +96,14 @@
 //		Fields("id, name").
 //		Source("users").
 //		Where("age > 18").
+//		OrderBy("created_at DESC").
 //		Limit(10).
 //		Offset(20).
 //		Build()
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//	fmt.Println(sql) // SELECT id, name FROM users WHERE age > 18 LIMIT 10 OFFSET 20
+//	fmt.Println(sql) // SELECT id, name FROM users WHERE age > 18 ORDER BY created_at DESC LIMIT 10 OFFSET 20
 //
 // With no fields specified, the builder defaults to:
 //

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -109,3 +109,17 @@ func ExampleSelectBuilder_whereReset() {
 	// Output:
 	// SELECT id FROM users WHERE role = 'admin'
 }
+
+// ExampleSelectBuilder_ordering demonstrates how to use OrderBy and ThenOrderBy
+// to build an ORDER BY clause in a SELECT statement.
+func ExampleSelectBuilder_ordering() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("id, name").
+		Source("users").
+		OrderBy("created_at DESC").
+		ThenOrderBy("id ASC").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT id, name FROM users ORDER BY created_at DESC, id ASC
+}

--- a/db/builder/select_test.go
+++ b/db/builder/select_test.go
@@ -254,6 +254,90 @@ func TestSelectBuilder(t *testing.T) {
 			})
 		})
 
+		t.Run("Sorting", func(t *testing.T) {
+			t.Run("NilCollection", func(t *testing.T) {
+				sb := &builder.SelectBuilder{} // sorting is nil
+				sb.Fields("id")
+				sb.Source("users")
+				sb.OrderBy("name ASC")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				expected := "SELECT id FROM users ORDER BY name ASC"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("OrderBy", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					OrderBy("created_at DESC")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users ORDER BY created_at DESC"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("ThenSort", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					OrderBy("created_at DESC").
+					ThenOrderBy("id ASC")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users ORDER BY created_at DESC, id ASC"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("ResetWithSortBy", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					OrderBy("name ASC").
+					OrderBy("email DESC") // should reset
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users ORDER BY email DESC"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("IgnoreEmptySorting", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					OrderBy("   ", "updated_at ASC")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users ORDER BY updated_at ASC"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+		})
+
 		t.Run("Limit", func(t *testing.T) {
 			sb := builder.NewSelect(nil).
 				Fields("id").


### PR DESCRIPTION
- Introduce .OrderBy() to set ORDER BY clause (resets previous ordering)
- Introduce .ThenOrderBy() to append additional ordering fields
- Add nil-safety for both conditions and sorting collections in Build()
- Update README.md and doc.go with strict examples and ordering docs
- Add example_test.go coverage for ordering to enforce doc consistency