### PR TITLE
feat(builder/select): add GroupBy support with tests and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,18 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [v1.13.0](https://github.com/entiqon/entiqon/releases/tag/v1.13.0) - 2025-08-23
+## [v1.13.0] - Upcoming
 
-### ✨ Features
-- **token/field**: add `Debug()` for compact diagnostics and enhance `String()` with ✅/⛔️ icons
-- **db/builder/select**: improve error reporting for invalid usage (clearer messages for unsupported inputs, missing sources, etc.)
-- **common/extension/integer**: introduce integer parser with full tests, examples, and parser shortcuts
+### Database (builder/select)
+- Added full clause support:
+    - **Conditions**: `Where`, `And`, `Or` (reset, append, normalize with AND, ignore empty).
+    - **Grouping**: `GroupBy`, `ThenGroupBy` (reset/append, ignore empty, rendered between WHERE and ORDER BY).
+    - **Ordering**: `OrderBy`, `ThenOrderBy` (reset/append, ignore empty, rendered after WHERE/GROUP BY).
+- Enhanced diagnostics & reporting:
+    - Invalid fields produce consistent `⛔️ Field("<expr>"): input type unsupported: <type>` errors.
+    - `Debug()` and `String()` improved with ✅/⛔️ status markers.
+    - `Build()` aggregates invalid fields, detects nil receiver and missing source, with clear ❌ messages.
 
-### 🧪 Tests
-- **builder/select**: reach 100% coverage for `SelectBuilder`
+### Common (extension/integer)
+- Introduced **integer parser**:
+    - `ParseFrom(any)` converts input safely to int, rejects invalid types.
+    - `IntegerOr` shortcut with defaults.
+    - Consistent with `boolean`, `float`, and `decimal` parsers.
 
-### 🛠 Internal
-- **gench utility**: add `gench` bash tool to automate changelog entry generation
+### Tests & Docs
+- Comprehensive unit tests across Database and Common ensuring 100% coverage.
+- **README.md** and **doc.go** updated with Conditions, Grouping, Ordering, and Integer parser sections.
+- Added runnable examples in `example_test.go` for all new features.
 
 ## [v1.12.0](https://github.com/entiqon/entiqon/releases/tag/v1.12.0) - 2025-08-22
 

--- a/db/builder/README.md
+++ b/db/builder/README.md
@@ -1,5 +1,5 @@
 <h1 align="left">
-  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96"> Builder
+  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96"> SelectBuilder
 </h1>
 <h6 align="left">Part of the <a href="https://github.com/entiqon/entiqon">Entiqon</a>::<span>Database</span> toolkit.</h6>
 
@@ -15,6 +15,7 @@ It is designed to be **simple**, **strict**, and **dialect-aware**.
   - Fields (`Fields`, `AddFields`) with strict rules
   - Source (`Source`)
   - Conditions (`Where`, `And`, `Or`)
+  - Grouping (`GroupBy`, `ThenGroupBy`)
   - Ordering (`OrderBy`, `ThenOrderBy`)
   - Pagination (`Limit`, `Offset`)
   - SQL rendering (`Build`, `String`)
@@ -121,6 +122,29 @@ Rules:
 
 ---
 
+### Grouping
+
+You can build `GROUP BY` clauses using `GroupBy` and `ThenGroupBy`:
+
+```go
+sql, _ := builder.NewSelect(nil).
+    Fields("id, COUNT(*) AS total").
+    Source("users").
+    GroupBy("department").
+    ThenGroupBy("role").
+    Build()
+
+fmt.Println(sql)
+// Output: SELECT id, COUNT(*) AS total FROM users GROUP BY department, role
+```
+
+Rules:
+- `GroupBy` resets grouping (like `Fields`).
+- `ThenGroupBy` appends additional grouping fields.
+- Empty or whitespace values are ignored.
+
+---
+
 ### Debugging Fields
 
 Use `String()` and `Debug()` to understand how a field was parsed:
@@ -178,13 +202,13 @@ Currently, supports:
 - Field selection and aliasing (strict rules enforced)
 - Single source
 - WHERE conditions with AND/OR composition
+- GROUP BY with multiple fields
 - ORDER BY with multiple fields
 - Limit and offset
 - Error reporting for invalid fields with ✅/⛔️ diagnostics
 
 Planned extensions include:
 - Joins
-- Grouping
 - Parameter binding
 
 ---

--- a/db/builder/doc.go
+++ b/db/builder/doc.go
@@ -1,7 +1,7 @@
 // Package builder provides a fluent API to construct SQL SELECT queries.
 //
 // The SelectBuilder type allows incremental composition of SELECT statements
-// with support for fields, sources, conditions, ordering, limits, and offsets.
+// with support for fields, sources, conditions, grouping, ordering, limits, and offsets.
 // It is simple, extensible, and dialect-aware.
 //
 // # Overview
@@ -25,6 +25,8 @@
 //   - Where(...string): reset and set conditions for the WHERE clause.
 //   - And(...string): append conditions with AND.
 //   - Or(...string): append conditions with OR.
+//   - GroupBy(...string): reset and set fields for the GROUP BY clause.
+//   - ThenGroupBy(...string): append additional GROUP BY fields.
 //   - OrderBy(...string): reset and set fields for the ORDER BY clause.
 //   - ThenOrderBy(...string): append additional ORDER BY fields.
 //   - Limit(int): apply LIMIT.
@@ -64,6 +66,25 @@
 //	sql, _ := sb.Build()
 //	// SELECT id, name FROM users WHERE age > 18 AND status = 'active' OR role = 'admin' AND country = 'US'
 //
+// # Grouping
+//
+// Grouping is expressed as raw strings (e.g. "department"). They are combined as follows:
+//
+//   - GroupBy() clears existing grouping and sets new ones.
+//   - ThenGroupBy() appends additional GROUP BY fields.
+//   - Empty or whitespace-only strings are ignored.
+//
+// For example:
+//
+//	sb := builder.NewSelect(nil).
+//		Fields("id, COUNT(*) AS total").
+//		Source("users").
+//		GroupBy("department").
+//		ThenGroupBy("role")
+//
+//	sql, _ := sb.Build()
+//	// SELECT id, COUNT(*) AS total FROM users GROUP BY department, role
+//
 // # Ordering
 //
 // Ordering is expressed as raw strings (e.g. "created_at DESC"). They are combined as follows:
@@ -96,6 +117,7 @@
 //		Fields("id, name").
 //		Source("users").
 //		Where("age > 18").
+//		GroupBy("department").
 //		OrderBy("created_at DESC").
 //		Limit(10).
 //		Offset(20).
@@ -103,7 +125,7 @@
 //	if err != nil {
 //		log.Fatal(err)
 //	}
-//	fmt.Println(sql) // SELECT id, name FROM users WHERE age > 18 ORDER BY created_at DESC LIMIT 10 OFFSET 20
+//	fmt.Println(sql) // SELECT id, name FROM users WHERE age > 18 GROUP BY department ORDER BY created_at DESC LIMIT 10 OFFSET 20
 //
 // With no fields specified, the builder defaults to:
 //

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -123,3 +123,17 @@ func ExampleSelectBuilder_ordering() {
 	fmt.Println(sql)
 	// Output: SELECT id, name FROM users ORDER BY created_at DESC, id ASC
 }
+
+// ExampleSelectBuilder_grouping demonstrates how to use GroupBy and ThenGroupBy
+// to build a GROUP BY clause in a SELECT statement.
+func ExampleSelectBuilder_grouping() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("department, COUNT(*) AS total").
+		Source("users").
+		GroupBy("department").
+		ThenGroupBy("role").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT department, COUNT(*) AS total FROM users GROUP BY department, role
+}

--- a/db/builder/select_test.go
+++ b/db/builder/select_test.go
@@ -254,6 +254,90 @@ func TestSelectBuilder(t *testing.T) {
 			})
 		})
 
+		t.Run("Grouping", func(t *testing.T) {
+			t.Run("NilCollection", func(t *testing.T) {
+				sb := &builder.SelectBuilder{} // groupings is nil
+				sb.Fields("id")
+				sb.Source("users")
+				sb.GroupBy("role")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				expected := "SELECT id FROM users GROUP BY role"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("GroupBy", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					GroupBy("department")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users GROUP BY department"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("ThenGroupBy", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					GroupBy("department").
+					ThenGroupBy("role")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users GROUP BY department, role"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("ResetWithGroupBy", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					GroupBy("department").
+					GroupBy("role") // should reset
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users GROUP BY role"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+
+			t.Run("IgnoreEmptyGrouping", func(t *testing.T) {
+				sb := builder.NewSelect(nil).
+					Fields("id").
+					Source("users").
+					GroupBy("   ", "department")
+
+				sql, err := sb.Build()
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				expected := "SELECT id FROM users GROUP BY department"
+				if sql != expected {
+					t.Errorf("expected %q, got %q", expected, sql)
+				}
+			})
+		})
+
 		t.Run("Sorting", func(t *testing.T) {
 			t.Run("NilCollection", func(t *testing.T) {
 				sb := &builder.SelectBuilder{} // sorting is nil

--- a/releases/release-notes-v1.13.0.md
+++ b/releases/release-notes-v1.13.0.md
@@ -1,47 +1,69 @@
-# Release v1.13.0 — Builder Conditions & Field Diagnostics
+# Release Notes — v1.13.0
 
-## 🚀 Features
+## Database Package (builder/select)
 
-- **db/builder/select**
-  - Introduced `Where()`, `And()`, and `Or()` methods for building `WHERE` clauses
-  - Normalization of multiple conditions:  
-    `Where("a", "b")` → `WHERE a AND b`
-  - `Where()` clears existing conditions (like `Fields()`), while `And()`/`Or()` append
-  - Defensive handling of manual initialization (`&SelectBuilder{}`)
-  - Simplified `Build()` logic for condition rendering
+### Added
+- Extended `SelectBuilder` with full clause support:
+  - **Conditions**
+    - `Where(...string)`: resets conditions
+    - `And(...string)`: appends with `AND`
+    - `Or(...string)`: appends with `OR`
+    - Multiple conditions in a single `Where` call are normalized with `AND`
+    - Ignores empty or whitespace-only inputs
+    - `Build()` renders conditions immediately after `FROM`
+  - **Grouping**
+    - `GroupBy(...string)`: resets grouping fields
+    - `ThenGroupBy(...string)`: appends grouping fields
+    - Graceful handling of nil collections
+    - Ignores empty or whitespace-only values
+    - `Build()` renders `GROUP BY` between `WHERE` and `ORDER BY`
+  - **Ordering**
+    - `OrderBy(...string)`: resets ordering fields
+    - `ThenOrderBy(...string)`: appends ordering fields
+    - Ignores empty or whitespace-only values
+    - `Build()` renders `ORDER BY` after `WHERE` / `GROUP BY`
 
-- **token/field**
-  - Added `Debug()` for compact diagnostic output:  
-    `✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]`  
-    `⛔️ Field("true"): [raw: false, aliased: false, errored: true] – input type unsupported: bool`
-  - Enhanced `String()` with ✅/⛔️ icons and explicit *wrong initialization* handling
+### Enhanced
+- **Field diagnostics**
+  - Invalid fields now produce consistent error messages
+  - Example: `⛔️ Field("true"): input type unsupported: bool`
+  - `Debug()` method on `token.Field` shows structured state with ✅/⛔️ markers
+  - `String()` enhanced for clarity and consistency with Debug output
+- **SelectBuilder reporting**
+  - `Build()` aggregates invalid field errors into a single descriptive block
+  - Clearer error messages when:
+    - No source specified (`❌ [Build] - No source specified`)
+    - Nil receiver (`❌ [Build] - Wrong initialization. Cannot build on receiver nil`)
+  - `String()` provides status-style output:
+    - ✅ successful SQL string with params
+    - ❌ error message when build fails
 
-## 🧪 Tests
+## Common Package (extension/integer)
 
-- 100% coverage for `SelectBuilder` and `token.Field`
-- Added test cases for:
-  - Defaults, single/multiple conditions, ignore empty
-  - `Where` reset behavior
-  - `And`/`Or` appends
-  - Edge case: mixed `AND` + `OR`
-  - Manual initialization (`&SelectBuilder{}`)
+### Added
+- Introduced integer parser with full support:
+  - `ParseFrom(any)` converts generic input into integer values
+  - Rejects non-integer inputs with clear error reporting
+  - Consistent behavior with existing parsers (`boolean`, `float`, `decimal`)
+  - Added parser shortcuts (`IntegerOr`) for default values
+- Full test coverage in `integer/parser_test.go`
+- Added runnable examples and integrated into `example_test.go`
+- Updated parser documentation under `common/extension` README
 
-## 📖 Documentation
+## Tests
+- Comprehensive unit tests across `db/builder/select` and `common/extension/integer` ensuring 100% coverage:
+  - Clause handling (nil, reset, append, overwrite, ignore-empty)
+  - Field validation and error aggregation
+  - Integer parsing (valid, invalid, defaults)
 
-- Updated `doc.go` for `builder` with conditions section
-- Added new `example_test.go` examples covering `Where`, `And`, `Or`, and reset semantics
-- Updated `field.md` guide with new `String()`/`Debug()` documentation
-- Updated `README.md` with:
-  - Strict **Field Rules**
-  - Examples of `Where`/`And`/`Or`
-  - Debugging output (`String()`/`Debug()`)
-  - Revised error cases
-  - Updated Status section
-
----
-
-## 📄 Summary
-
-This release introduces **full WHERE clause support** with `Where`/`And`/`Or` methods,  
-improves **diagnostics for fields** with ✅/⛔️ outputs, and ensures **100% test coverage**.  
-All docs (README, guides, examples) have been updated accordingly.
+## Documentation
+- **Database README.md** updated with Conditions, Grouping, Ordering, and Field Rules
+- **Common/Extension README.md** updated with integer parser, usage table, and shortcuts
+- **Database doc.go** extended with clause usage examples
+- **Database example_test.go** enhanced with runnable examples:
+  - `ExampleSelectBuilder_where`
+  - `ExampleSelectBuilder_andOr`
+  - `ExampleSelectBuilder_ordering`
+  - `ExampleSelectBuilder_grouping`
+- **Common example_test.go** enhanced with runnable examples:
+  - `ExampleIntegerParseFrom` and shortcut usage


### PR DESCRIPTION
- Introduce grouping support in SelectBuilder:
  - GroupBy(...string): resets grouping fields
  - ThenGroupBy(...string): appends grouping fields
  - Empty/whitespace values ignored
- Update Build() to render GROUP BY between WHERE and ORDER BY
- Add comprehensive unit tests covering nil, reset, append, ignore-empty cases
- Extend example_test.go with ExampleSelectBuilder_grouping
- Update README.md:
  - Add Grouping to Features
  - New section with usage and rules
  - Remove from planned extensions
- Update doc.go with Grouping methods, rules, and example

Result: grouping is now fully supported, documented, and tested.