### PR TITLE
feat(builder/select): add Having clause support to SelectBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Database (builder/select)
 - Added full clause support:
     - **Conditions**: `Where`, `And`, `Or` (reset, append, normalize with AND, ignore empty).
-    - **Grouping**: `GroupBy`, `ThenGroupBy` (reset/append, ignore empty, rendered between WHERE and ORDER BY).
-    - **Ordering**: `OrderBy`, `ThenOrderBy` (reset/append, ignore empty, rendered after WHERE/GROUP BY).
+    - **Grouping**: `GroupBy`, `ThenGroupBy` (reset/append, ignore empty, rendered between WHERE and HAVING).
+    - **Having**: `Having`, `AndHaving`, `OrHaving` (reset/append, normalize with AND, ignore empty, rendered after GROUP BY).
+    - **Ordering**: `OrderBy`, `ThenOrderBy` (reset/append, ignore empty, rendered after GROUP BY/HAVING).
 - Enhanced diagnostics & reporting:
     - Invalid fields produce consistent `⛔️ Field("<expr>"): input type unsupported: <type>` errors.
     - `Debug()` and `String()` improved with ✅/⛔️ status markers.
@@ -25,8 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Tests & Docs
 - Comprehensive unit tests across Database and Common ensuring 100% coverage.
-- **README.md** and **doc.go** updated with Conditions, Grouping, Ordering, and Integer parser sections.
-- Added runnable examples in `example_test.go` for all new features.
+- **README.md**, **doc.go**, and **example_test.go** updated with Conditions, Grouping, Having, Ordering, and Integer parser sections.
+- Added runnable examples in `example_test.go` demonstrating new Having clause.
 
 ## [v1.12.0](https://github.com/entiqon/entiqon/releases/tag/v1.12.0) - 2025-08-22
 
@@ -224,7 +225,7 @@ It's the first practical application of the previously introduced `AliasableToke
 
 ---
 
-## \[v1.3.0] - 2025-05-19
+## [v1.3.0] - 2025-05-19
 
 ### ✨ Added
 
@@ -252,7 +253,7 @@ It's the first practical application of the previously introduced `AliasableToke
 
 ---
 
-## \[v1.2.0] - 2025-05-18
+## [v1.2.0] - 2025-05-18
 
 ### 📚 Documentation
 
@@ -280,7 +281,7 @@ operations.
 
 ---
 
-## \[v1.1.0] - 2025-05-17
+## [v1.1.0] - 2025-05-17
 
 ### ✨ Added
 
@@ -313,10 +314,10 @@ future engines.
 
 ---
 
-## \[v1.0.0] - 2025-05-16
+## [v1.0.0] - 2025-05-16
 
 ### Added
 
 * `SelectBuilder` upgraded to support argument binding and structured condition handling
 * Consistent `Build() (string, []any, error)` signature across all builders
-* Enhanced \`ConditionToken
+* Enhanced `ConditionToken

--- a/db/builder/README.md
+++ b/db/builder/README.md
@@ -16,6 +16,7 @@ It is designed to be **simple**, **strict**, and **dialect-aware**.
   - Source (`Source`)
   - Conditions (`Where`, `And`, `Or`)
   - Grouping (`GroupBy`, `ThenGroupBy`)
+  - Having (`Having`, `AndHaving`, `OrHaving`)
   - Ordering (`OrderBy`, `ThenOrderBy`)
   - Pagination (`Limit`, `Offset`)
   - SQL rendering (`Build`, `String`)
@@ -145,6 +146,33 @@ Rules:
 
 ---
 
+### Having
+
+You can build `HAVING` clauses using `Having`, `AndHaving`, and `OrHaving`:
+
+```go
+sql, _ := builder.NewSelect(nil).
+    Fields("department, COUNT(*) AS total").
+    Source("users").
+    GroupBy("department").
+    Having("COUNT(*) > 5").
+    AndHaving("AVG(age) > 30").
+    OrHaving("SUM(salary) > 100000").
+    Build()
+
+fmt.Println(sql)
+// Output: SELECT department, COUNT(*) AS total FROM users GROUP BY department HAVING COUNT(*) > 5 AND AVG(age) > 30 OR SUM(salary) > 100000
+```
+
+Rules:
+- `Having` resets conditions (like `Where`).
+- `AndHaving` appends with `AND`.
+- `OrHaving` appends with `OR`.
+- Multiple conditions in one `Having(...)` are normalized with `AND`.
+- Empty or whitespace values are ignored.
+
+---
+
 ### Debugging Fields
 
 Use `String()` and `Debug()` to understand how a field was parsed:
@@ -203,6 +231,7 @@ Currently, supports:
 - Single source
 - WHERE conditions with AND/OR composition
 - GROUP BY with multiple fields
+- HAVING with AND/OR composition
 - ORDER BY with multiple fields
 - Limit and offset
 - Error reporting for invalid fields with ✅/⛔️ diagnostics

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -137,3 +137,20 @@ func ExampleSelectBuilder_grouping() {
 	fmt.Println(sql)
 	// Output: SELECT department, COUNT(*) AS total FROM users GROUP BY department, role
 }
+
+// ExampleSelectBuilder_having demonstrates how to use Having, AndHaving,
+// and OrHaving to build a HAVING clause in a SELECT statement.
+func ExampleSelectBuilder_having() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("department, COUNT(*) AS total").
+		Source("users").
+		GroupBy("department").
+		Having("COUNT(*) > 5").
+		AndHaving("AVG(age) > 30").
+		OrHaving("SUM(salary) > 100000").
+		Build()
+
+	fmt.Println(sql)
+	// Output:
+	// SELECT department, COUNT(*) AS total FROM users GROUP BY department HAVING COUNT(*) > 5 AND AVG(age) > 30 OR SUM(salary) > 100000
+}

--- a/releases/release-notes-v1.13.0.md
+++ b/releases/release-notes-v1.13.0.md
@@ -16,12 +16,19 @@
     - `ThenGroupBy(...string)`: appends grouping fields
     - Graceful handling of nil collections
     - Ignores empty or whitespace-only values
-    - `Build()` renders `GROUP BY` between `WHERE` and `ORDER BY`
+    - `Build()` renders `GROUP BY` between `WHERE` and `HAVING`
+  - **Having**
+    - `Having(...string)`: resets HAVING conditions
+    - `AndHaving(...string)`: appends with `AND`
+    - `OrHaving(...string)`: appends with `OR`
+    - Multiple conditions in a single `Having` call are normalized with `AND`
+    - Ignores empty or whitespace-only inputs
+    - `Build()` renders `HAVING` immediately after `GROUP BY`
   - **Ordering**
     - `OrderBy(...string)`: resets ordering fields
     - `ThenOrderBy(...string)`: appends ordering fields
     - Ignores empty or whitespace-only values
-    - `Build()` renders `ORDER BY` after `WHERE` / `GROUP BY`
+    - `Build()` renders `ORDER BY` after `WHERE` / `GROUP BY` / `HAVING`
 
 ### Enhanced
 - **Field diagnostics**
@@ -57,7 +64,7 @@
   - Integer parsing (valid, invalid, defaults)
 
 ## Documentation
-- **Database README.md** updated with Conditions, Grouping, Ordering, and Field Rules
+- **Database README.md** updated with Conditions, Grouping, Having, Ordering, and Field Rules
 - **Common/Extension README.md** updated with integer parser, usage table, and shortcuts
 - **Database doc.go** extended with clause usage examples
 - **Database example_test.go** enhanced with runnable examples:
@@ -65,5 +72,6 @@
   - `ExampleSelectBuilder_andOr`
   - `ExampleSelectBuilder_ordering`
   - `ExampleSelectBuilder_grouping`
+  - `ExampleSelectBuilder_having`
 - **Common example_test.go** enhanced with runnable examples:
   - `ExampleIntegerParseFrom` and shortcut usage


### PR DESCRIPTION
- Introduced HAVING clause handling with:
  - Having(...string): reset and set conditions
  - AndHaving(...string): append conditions with AND
  - OrHaving(...string): append conditions with OR
  - Normalizes multiple conditions with AND, ignores empty values
  - Rendered immediately after GROUP BY and before ORDER BY
- Extended Build() to include HAVING
- Added full test suite (NilCollection, Single, Multiple, IgnoreEmpty, ResetCollection, And, Or)
- Added example in example_test.go (ExampleSelectBuilder_having)
- Updated README.md, doc.go, and CHANGELOG with Having section
- Release notes updated to document Having support

✨ Time for Having!