### PR TITLE
chore(github): add contributing guides, templates, and funding config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,102 @@
+# Contributing to Entiqon
+
+Welcome! 🎉 We’re excited that you’re interested in contributing to Entiqon.  
+This guide explains the conventions we follow for commits, tests, documentation, and releases.  
+Consistency is key — every contribution should match the project’s style and rigor.
+
+---
+
+## 🧪 Testing
+
+We require **80% test coverage**.  
+Follow this structure for all tests:
+
+- **Pattern**: `file → methods → cases`
+- **Naming**: Always **PascalCase**, no underscores.
+- **Case organization**: Use `t.Run` blocks to express hierarchy clearly.
+
+Example:
+```go
+t.Run("Methods", func(t *testing.T) {
+    t.Run("Having", func(t *testing.T) {
+        t.Run("ResetCollection", func(t *testing.T) {
+            // ...
+        })
+    })
+})
+```
+
+Edge cases are **mandatory** (nil receivers, empty collections, invalid input, etc.).
+
+---
+
+## 📑 Documentation
+
+Every feature must be reflected in:
+- `doc.go` → Package-level usage and examples.
+- `README.md` → High-level feature documentation with runnable snippets.
+- `example_test.go` → Go runnable examples (`ExampleXxx` functions).
+- `CHANGELOG.md` → Notable changes, grouped by release.
+- `release-notes-vX.Y.Z.md` → Detailed notes for GitHub releases.
+
+If a feature is not in all of these, it’s **not complete**.
+
+---
+
+## 💬 Commit Messages
+
+We use [Conventional Commits](https://www.conventionalcommits.org/) with semantic prefixes.
+
+- **Format**:
+  ```
+  feat(scope): short description
+  ```
+- **Body**: Explain *what* and *why*. List sub-bullets for details (API, tests, docs).
+- **Style**: Clear, consistent, and with personality ✨
+
+Example (detailed commit):
+```text
+feat(builder/select): add Having clause support to SelectBuilder
+
+- Introduced Having(), AndHaving(), OrHaving() for HAVING clause
+- Integrated into Build() after GROUP BY
+- Added tests (NilCollection, Single, Multiple, IgnoreEmpty, ResetCollection, And, Or)
+- Updated README.md, doc.go, example_test.go, and CHANGELOG
+- Release notes updated to document Having support
+
+✨ Time for Having!
+```
+
+### Squash Commits
+If squashing multiple commits:
+- Keep the subject line short.
+- Body = concise summary of changes.
+
+Example (squash):
+```text
+feat(builder/select): add Having clause support
+
+- New methods: Having, AndHaving, OrHaving
+- Integrated into Build() after GROUP BY
+- Tests, docs, examples, and release notes updated
+```
+
+---
+
+## 🚀 Release Process
+
+1. **Finish features** → Ensure tests/docs/README/example_test are all updated.  
+2. **Update docs** → `README.md`, `doc.go`, examples.  
+3. **Update CHANGELOG.md** → Add entries under the current “Upcoming” section.  
+4. **Update release notes** → `release-notes-vX.Y.Z.md`.  
+5. **Tag and publish** → When ready, create a GitHub release with `gh release create`.  
+
+---
+
+## ✅ Summary
+
+- Write tests first (nil → valid → edge).
+- Update **all docs** (README, doc.go, examples).
+- Follow **commit conventions** (detailed vs squash).
+- Keep CHANGELOG and release notes up to date.
+- Add some flair: ✅/⛔️ markers, fun phrases like *“Time for Having!”* make the project memorable.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,15 @@
+# These are supported funding model platforms
+
+github: [ialopezg]
+patreon: ialopezg
+open_collective: ialopezg
+ko_fi: ialopezg
+tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
+community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
+liberapay: # Replace with a single Liberapay username
+issuehunt: # Replace with a single IssueHunt username
+otechie: # Replace with a single Otechie username
+custom:
+  - "https://www.paypal.com/donate/?hosted_button_id=GSZ7HDBKGNPPJ"
+  - "https://buymeacoffee.com/entiqon"
+  - "https://entiqon.dev/sponsor"

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,57 @@
+---
+name: "🐛 Bug Report"
+about: Report a reproducible bug or regression in Entiqon.
+title: ''
+labels: bug, requires triage
+assignees: ''
+---
+
+## 📝 Description
+
+<!-- A clear and concise description of the problem. -->
+
+### ✅ Expected Behavior
+<!-- What did you expect to happen? -->
+
+### ❌ Actual Behavior
+<!-- What actually happened? If applicable, include error output in code blocks. -->
+
+```text
+// Example error or log output here
+```
+
+### 🧩 Steps to Reproduce
+
+<!-- Provide a minimal, complete, verifiable example (MCVE). -->
+
+1. …
+2. …
+
+```go
+// Example Go code that reproduces the issue
+```
+
+### 🌍 Environment
+
+| Dependency          | Version  |
+| ------------------- | -------- |
+| Operating System    |          |
+| Go version          | `go version` output |
+| Entiqon version     | `git describe --tags` or commit SHA |
+| Other dependencies  | e.g. Postgres, MySQL, etc. |
+
+### ➕ Additional Context
+<!-- Add any other context about the problem here. -->
+
+---
+
+### 🙋 Willing to Help?
+
+- ✅ Yes, I can open a PR to fix this  
+- ✖️ Yes, but I’ll need guidance  
+- ✖️ No, but I can support development (sponsor/donate)  
+- ✖️ No, I’ll wait for the community/maintainers to fix  
+
+---
+
+✨ Thanks for reporting! First-time contributors are always welcome 🙌

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+
+contact_links:
+  - name: 🤔 Questions, General Support, and Help
+    url: https://github.com/entiqon/entiqon/blob/main/docs/documentation_issue.md
+    about: This issue tracker is not for support questions. Please refer to the support documentation.

--- a/.github/ISSUE_TEMPLATE/documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/documentation_issue.md
@@ -1,0 +1,34 @@
+---
+name: 📝 Documentation Issue
+about: Report unclear, missing, or incorrect documentation in Entiqon.
+title: ''
+labels: documentation, requires triage
+assignees: ''
+---
+
+## 📖 Documentation Issue
+
+### ❓ What was unclear or insufficient?
+
+<!-- Be specific: file name, section, or link to the page in the repo. -->
+
+### 💡 Recommended Fix
+
+<!-- Suggest how to improve: add examples, clarify language, restructure, etc. -->
+
+### ➕ Additional Context
+
+<!-- Any extra info that may help maintainers understand the problem. -->
+
+---
+
+### 🙋 Willing to Help?
+
+- ✅ Yes, I can open a PR to fix this  
+- ✖️ Yes, but I’ll need guidance  
+- ✖️ No, but I can support development (sponsor/donate)  
+- ✖️ No, I’ll wait for the community/maintainers to fix  
+
+---
+
+✨ Thanks for helping improve the docs! 🙌

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,38 @@
+---
+name: 🌈 Feature Request
+about: Suggest a new feature or enhancement for Entiqon.
+title: ''
+labels: new feature, requires triage
+assignees: ''
+---
+
+## 🌟 Feature Description
+
+### ❓ The Problem
+
+<!-- A clear description of the problem or gap this feature addresses. -->
+
+### 💡 Proposed Solution
+
+<!-- Describe the new capability and how it solves the problem. -->
+
+### 🔄 Alternatives Considered
+
+<!-- List any alternatives, workarounds, or reasons this is the best solution. -->
+
+### ➕ Additional Context
+
+<!-- Add any extra context, screenshots, or examples here. -->
+
+---
+
+### 🙋 Willing to Help?
+
+- ✅ Yes, I can open a PR to implement this  
+- ✖️ Yes, but I’ll need guidance  
+- ✖️ No, but I can support development (sponsor/donate)  
+- ✖️ No, I’ll wait for the community/maintainers to implement  
+
+---
+
+✨ Thanks for helping shape Entiqon’s future! 🚀

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+# 📝 Contributor Quick Reference
+
+## ✅ Before Commit
+- [ ] Tests written and passing (nil → valid → edge cases).  
+- [ ] Tests follow `file → methods → cases` pattern with **PascalCase**.  
+- [ ] Docs updated:
+  - [ ] `doc.go`
+  - [ ] `README.md`
+  - [ ] `example_test.go`
+  - [ ] `CHANGELOG.md`
+  - [ ] `release-notes-vX.Y.Z.md`
+
+## 💬 Commit Rules
+- Use **Conventional Commits**:
+  - `feat(scope): ...` → new feature  
+  - `fix(scope): ...` → bug fix  
+  - `docs(scope): ...` → docs only  
+  - `refactor(scope): ...` → no behavior change  
+- Detailed commits → list features, tests, docs.  
+- Squash commits → short summary.  
+
+Examples:  
+```text
+feat(builder/select): add Having clause support
+
+- New methods: Having, AndHaving, OrHaving
+- Integrated into Build() after GROUP BY
+- Tests, docs, examples, and release notes updated
+```
+
+## 🚀 Release Flow
+1. Ensure **100% coverage**.  
+2. Update **docs + examples**.  
+3. Update **CHANGELOG** (under "Upcoming").  
+4. Update **release notes** file.  
+5. Tag & release with `gh release create`.  
+
+## ✨ Style
+- ✅ / ⛔️ markers in errors and docs.  
+- Optional: add a fun closing phrase in commits, e.g.:  
+  ```
+  ✨ Time for Having!
+  ```
+
+---
+
+## ✨ Notes for Reviewers
+
+Please describe any additional context, special considerations, or follow-up work here.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@
 
 ---
 
+## 🤝 Contributing
+
+We welcome contributions! 🎉
+
+Please read the [CONTRIBUTING.md](./.github/CONTRIBUTING.md) guide for details on:
+- Writing tests
+- Commit message conventions
+- Documentation updates
+- Release process
+
+For a quick checklist, see [CONTRIBUTING_QUICK.md](./.github/CONTRIBUTING_QUICK.md).
+
+---
+
 ## 📄 License
 
 💡 Originally created by [Isidro Lopez](https://github.com/ialopezg)  


### PR DESCRIPTION
- Added CONTRIBUTING.md (full guide) and CONTRIBUTING_QUICK.md (checklist)
- Added PULL_REQUEST_TEMPLATE.md with contributor quick reference
- Updated PR template to mark fun commit phrase as optional
- Added FUNDING.yml with sponsor/custom support links
- Refreshed issue templates under .github/ISSUE_TEMPLATE:
  - bug_report.md (modernized for Entiqon)
  - documentation_issue.md (clarified for Entiqon)
  - feature_request.md (clarified for Entiqon)