### PR TITLE
feat(contract): extend Errorable with SetError for token state mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - Added BaseToken section with purpose, methods, and usage
     - Streamlined layout, removed redundancy
     - Extended philosophy with **Consistency** principle: all tokens share BaseToken
+- Extended **Errorable** contract with `SetError(err error)`:
+    - Allows tokens/builders to mark themselves as errored after construction
+    - Implemented in `Field` and `Table` tokens
+    - Updated `doc.go`, `README.md`, and `example_test.go` to demonstrate usage
   
 ### Database (token/table)
 - Introduced **Table token** to represent SQL sources in builders:

--- a/db/builder/select.go
+++ b/db/builder/select.go
@@ -305,7 +305,7 @@ func (b *SelectBuilder) Build() (string, error) {
 	for _, f := range b.fields.Items() {
 		if f.IsErrored() {
 			bad = append(bad,
-				fmt.Sprintf("⛔️ Field(%q): %v", f.Input, f.Error))
+				fmt.Sprintf("⛔️ Field(%q): %v", f.Input, f.Error()))
 			continue
 		}
 		parts = append(parts, f.Render())

--- a/db/builder/select_test.go
+++ b/db/builder/select_test.go
@@ -19,8 +19,8 @@ func TestSelectBuilder(t *testing.T) {
 				sb := &builder.SelectBuilder{} // fields is nil
 				sb.Fields("id")
 				fields := sb.GetFields()
-				field, _ := fields.At(0)
-				if fields.Length() != 1 || field.Expr != "id" {
+				f, _ := fields.At(0)
+				if fields.Length() != 1 || f.Expr != "id" {
 					t.Errorf("expected one field 'id', got %+v", fields)
 				}
 			})
@@ -36,8 +36,8 @@ func TestSelectBuilder(t *testing.T) {
 			t.Run("Add", func(t *testing.T) {
 				sb := builder.NewSelect(nil).Fields("id")
 				fields := sb.GetFields()
-				field, _ := fields.At(0)
-				if fields.Length() != 1 || field.Expr != "id" {
+				f, _ := fields.At(0)
+				if fields.Length() != 1 || f.Expr != "id" {
 					t.Errorf("expected reset only, got %+v", fields)
 				}
 			})
@@ -47,8 +47,8 @@ func TestSelectBuilder(t *testing.T) {
 					Fields("id").
 					Fields("reset") // should reset
 				fields := sb.GetFields()
-				field, _ := fields.At(0)
-				if fields.Length() != 1 || field.Expr != "reset" {
+				f, _ := fields.At(0)
+				if fields.Length() != 1 || f.Expr != "reset" {
 					t.Errorf("expected reset only, got %+v", fields)
 				}
 			})
@@ -83,11 +83,11 @@ func TestSelectBuilder(t *testing.T) {
 			t.Run("Invalid", func(t *testing.T) {
 				sb := builder.NewSelect(nil).Fields(true)
 				fields := sb.GetFields()
-				field, _ := fields.At(0)
-				if !field.IsErrored() {
-					t.Errorf("expected IsErrored to be true, got %v", field.IsErrored())
+				f, _ := fields.At(0)
+				if !f.IsErrored() {
+					t.Errorf("expected IsErrored to be true, got %v", f.IsErrored())
 				}
-				if field.Error == nil {
+				if f.Error() == nil {
 					t.Errorf("expected Error to be set, got nil")
 				}
 			})

--- a/db/contract/README.md
+++ b/db/contract/README.md
@@ -1,5 +1,5 @@
 <h1 align="left">
-  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="82" width="82"> Core Contract
+  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="82" width="82" alt="entiqon"> Core Contract
 </h1>
 <h6 align="left">Part of the <a href="../../README.md">Entiqon</a> / <a href="../README.md">Database</a> toolkit.</h6>
 
@@ -50,10 +50,11 @@ narrow capability that can be composed with others.
 - **Method**: `Clone() T`
 
 ### [Errorable](./errorable.go)
-- **Purpose**: Error state inspection for tokens/builders.
+- **Purpose**: Error state inspection and propagation for tokens/builders.
 - **Methods**:
   - `IsErrored() bool`
   - `Error() error`
+  - `SetError(err error)`
 
 ---
 
@@ -75,6 +76,12 @@ fmt.Println(r.Render())
 var e contract.Errorable = table.New("users AS")
 fmt.Println(e.IsErrored()) // true
 fmt.Println(e.Error())     // invalid format "users AS"
+
+// Example of SetError usage
+tok := table.New("products")
+et := tok.(*table.Table)
+et.SetError(fmt.Errorf("manual mark as errored"))
+fmt.Println(et.IsErrored()) // true
 ```
 
 ---

--- a/db/contract/doc.go
+++ b/db/contract/doc.go
@@ -12,6 +12,7 @@
 //   - Stringable: human-facing representation for logs and audits.
 //   - Debuggable: developer-facing diagnostic view of internal state.
 //   - Clonable[T]: semantic clone for safe mutation.
+//   - Errorable: inspection and propagation of construction/validation errors.
 //
 // Separation of concerns:
 //
@@ -21,6 +22,7 @@
 //   - Stringable → logs/audit
 //   - Debuggable → developer diagnostics
 //   - Clonable[T] → safe duplication
+//   - Errorable → error state management and reporting
 //
 // Example:
 //
@@ -35,6 +37,7 @@
 //	type ExampleToken struct {
 //	    Name  string
 //	    Alias string
+//	    err   error
 //	}
 //
 //	func (e ExampleToken) Render() string   { return fmt.Sprintf("%s AS %s", e.Name, e.Alias) }
@@ -44,6 +47,9 @@
 //	func (e ExampleToken) Clone() *ExampleToken {
 //	    return &ExampleToken{Name: e.Name, Alias: e.Alias}
 //	}
+//	func (e ExampleToken) IsErrored() bool  { return e.err != nil }
+//	func (e ExampleToken) Error() error     { return e.err }
+//	func (e *ExampleToken) SetError(err error) { e.err = err }
 //
 //	func main() {
 //	    var bt contract.BaseToken = ExampleToken{Name: "users", Alias: "u"}
@@ -52,6 +58,7 @@
 //	    var s contract.Stringable = ExampleToken{Name: "users", Alias: "u"}
 //	    var d contract.Debuggable = ExampleToken{Name: "users", Alias: "u"}
 //	    var c contract.Clonable[*ExampleToken] = ExampleToken{Name: "users", Alias: "u"}
+//	    var e contract.Errorable  = &ExampleToken{Name: "users", Alias: "u"}
 //
 //	    fmt.Println(bt.Input(), bt.Expr(), bt.Alias(), bt.IsAliased(), bt.IsValid())
 //	    fmt.Println(r.Render()) // dialect-aware SQL
@@ -59,5 +66,6 @@
 //	    fmt.Println(s.String()) // audit/log
 //	    fmt.Println(d.Debug())  // developer diagnostic
 //	    fmt.Println(c.Clone())  // safe copy
+//	    fmt.Println(e.IsErrored(), e.Error()) // error state
 //	}
 package contract

--- a/db/contract/errorable.go
+++ b/db/contract/errorable.go
@@ -2,7 +2,7 @@
  * @Author: Isidro Lopez isidro.lopezg@live.com
  * @Date: 2025-08-24 05:42:00
  * @LastEditors: Isidro Lopez isidro.lopezg@live.com
- * @LastEditTime: 2025-08-24 05:42:04
+ * @LastEditTime: 2025-08-25 14:30:07
  * @FilePath: db/contract/errorable.go
  * @Description: 这是默认设置,可以在设置》工具》File Description中进行配置
  */
@@ -43,4 +43,8 @@ type Errorable interface {
 	// Error returns the underlying error if any.
 	// Returns nil if the object is valid.
 	Error() error
+
+	// SetError marks the token as errored with the given error.
+	// Implementations must store the error for reporting in Error().
+	SetError(err error)
 }

--- a/db/contract/example_test.go
+++ b/db/contract/example_test.go
@@ -42,9 +42,18 @@ func ExampleErrorable() {
 	var e contract.Errorable = t
 	fmt.Println(e.IsErrored())
 	fmt.Println(e.Error())
+
+	// manually mark an otherwise valid table as errored
+	valid := table.New("products")
+	valid.SetError(fmt.Errorf("manual mark as errored"))
+	fmt.Println(valid.IsErrored())
+	fmt.Println(valid.Error())
+
 	// Output:
 	// true
 	// invalid format "users AS"
+	// true
+	// manual mark as errored
 }
 
 // ExampleRawable demonstrates using a Table as a Rawable.

--- a/db/token/field/field_test.go
+++ b/db/token/field/field_test.go
@@ -24,8 +24,8 @@ func TestField(t *testing.T) {
 			t.Run("Field", func(t *testing.T) {
 				src := field.NewField("col1")
 				f := field.NewField(src)
-				if f.Error == nil || !errors.Is(f.Error, f.Error) {
-					t.Errorf("expected error about Clone, got %+v", f.Error)
+				if f.Error() == nil {
+					t.Errorf("expected error about Clone, got %+v", f.Error())
 				}
 			})
 
@@ -45,8 +45,8 @@ func TestField(t *testing.T) {
 				t.Run("WithParenthesis", func(t *testing.T) {
 					src := field.NewField("(col1 || '-' || col2)", " mixed")
 					f := field.NewField(src)
-					if f.Error == nil || !errors.Is(f.Error, f.Error) {
-						t.Errorf("expected error about Clone, got %+v", f.Error)
+					if f.Error() == nil {
+						t.Errorf("expected error about Clone, got %+v", f.Error())
 					}
 				})
 
@@ -105,14 +105,14 @@ func TestField(t *testing.T) {
 							f := field.NewField(tt.input)
 
 							if tt.expectErr {
-								if f.Error == nil {
+								if f.Error() == nil {
 									t.Errorf("expected error, got nil")
 								}
 								return
 							}
 
-							if f.Error != nil {
-								t.Errorf("unexpected error: %v", f.Error)
+							if f.Error() != nil {
+								t.Errorf("unexpected error: %v", f.Error())
 							}
 
 							if f.IsRaw != tt.expectRaw {
@@ -181,8 +181,8 @@ func TestField(t *testing.T) {
 
 			t.Run("UnsupportedType", func(t *testing.T) {
 				f := field.NewField(123)
-				if f.Error == nil || !strings.Contains(f.Error.Error(), "input type unsupported: int") {
-					t.Errorf("expected unsupported expr type error, got %+v", f.Error)
+				if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
+					t.Errorf("expected unsupported expr type error, got %+v", f.Error())
 				}
 			})
 
@@ -218,8 +218,8 @@ func TestField(t *testing.T) {
 
 		t.Run("TwoArgsAliasUnsupportedType", func(t *testing.T) {
 			f := field.NewField("col1", 123)
-			if f.Error == nil || !strings.Contains(f.Error.Error(), "input type unsupported: int") {
-				t.Errorf("expected unsupported alias type error, got %+v", f.Error)
+			if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
+				t.Errorf("expected unsupported alias type error, got %+v", f.Error())
 			}
 		})
 
@@ -232,23 +232,23 @@ func TestField(t *testing.T) {
 
 		t.Run("ThreeArgsAliasWrongType", func(t *testing.T) {
 			f := field.NewField("input1", 123, true)
-			if f.Error == nil || !strings.Contains(f.Error.Error(), "input type unsupported: int") {
-				t.Errorf("expected unsupported type error, got %+v", f.Error)
+			if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
+				t.Errorf("expected unsupported type error, got %+v", f.Error())
 			}
 		})
 
 		t.Run("ThreeArgsIsRawWrongType", func(t *testing.T) {
 			f := field.NewField("input1", "alias1", "yes")
-			if f.Error == nil || f.Error.Error() != "isRaw must be a bool" {
-				t.Errorf("expected isRaw must be a bool error, got %+v", f.Error)
+			if f.Error() == nil || f.Error().Error() != "isRaw must be a bool" {
+				t.Errorf("expected isRaw must be a bool error, got %+v", f.Error())
 			}
 		})
 
 		t.Run("InvalidSignatureFourArgs", func(t *testing.T) {
 			// expr, alias, isRaw
 			f1 := field.NewField("col1", "alias1", true, "yes")
-			if f1.Error == nil || f1.Error.Error() != "invalid NewField signature" {
-				t.Errorf("expected invalid NewField signature error, got %+v", f1.Error)
+			if f1.Error() == nil || f1.Error().Error() != "invalid NewField signature" {
+				t.Errorf("expected invalid NewField signature error, got %+v", f1.Error())
 			}
 		})
 
@@ -268,10 +268,10 @@ func TestField(t *testing.T) {
 			})
 
 			t.Run("NilReceiver", func(t *testing.T) {
-				var field *field.Field = nil
-				got := field.Clone()
+				var f *field.Field = nil
+				got := f.Clone()
 				if got != nil {
-					t.Errorf("cloned field = %+v, want %+v", got, field)
+					t.Errorf("cloned field = %+v, want %+v", got, f)
 				}
 			})
 		})
@@ -300,7 +300,7 @@ func TestField(t *testing.T) {
 			if f.IsErrored() {
 				t.Error("expected IsErrored false when Error is nil")
 			}
-			f.Error = errors.New("some error")
+			f.SetError(errors.New("some error"))
 			if !f.IsErrored() {
 				t.Error("expected IsErrored true when Error set")
 			}
@@ -311,7 +311,7 @@ func TestField(t *testing.T) {
 			if !f.IsValid() {
 				t.Error("expected IsValid true when no Error and Expr non-empty")
 			}
-			f.Error = errors.New("some error")
+			f.SetError(errors.New("some error"))
 			if f.IsValid() {
 				t.Error("expected IsValid false when Error set")
 			}
@@ -382,7 +382,7 @@ func TestField(t *testing.T) {
 			if !strings.Contains(got, "field AS Alias") {
 				t.Errorf("String() with alias got %q, want alias: true", got)
 			}
-			f.Error = errors.New("some error")
+			f.SetError(errors.New("some error"))
 			got = f.String()
 			if !strings.Contains(got, "⛔️") || !strings.Contains(got, "some error") {
 				t.Errorf("String() errored got %q, want icon and error message", got)

--- a/db/token/table/table.go
+++ b/db/token/table/table.go
@@ -139,6 +139,9 @@ func New(args ...string) *Table {
 	return t
 }
 
+// IsAliased reports whether the table has an alias.
+func (t *Table) IsAliased() bool { return t.alias != "" }
+
 // Clone returns a semantic copy of the Table.
 func (t *Table) Clone() *Table {
 	return &Table{
@@ -169,14 +172,15 @@ func (t *Table) Debug() string {
 	return fmt.Sprintf("✅ Table(%q): %s", t.input, flags)
 }
 
+// IsErrored reports whether the Table was constructed with an error.
+func (t *Table) IsErrored() bool { return t.err != nil }
+
 // Error returns the underlying construction error, if any.
 func (t *Table) Error() error { return t.err }
 
-// IsAliased reports whether the table has an alias.
-func (t *Table) IsAliased() bool { return t.alias != "" }
-
-// IsErrored reports whether the Table was constructed with an error.
-func (t *Table) IsErrored() bool { return t.err != nil }
+// SetError assigns an error to the table. Intended for use during
+// construction/parsing to capture validation failures.
+func (t *Table) SetError(err error) { t.err = err }
 
 // IsRaw reports whether the Table was explicitly constructed as raw
 // (via the two-argument form or as a subquery).

--- a/releases/release-notes-v1.13.0.md
+++ b/releases/release-notes-v1.13.0.md
@@ -58,6 +58,10 @@
     - New BaseToken section with purpose, methods, usage
     - Streamlined documentation structure
     - Extended philosophy with **Consistency** principle: all tokens share BaseToken
+- Extended **Errorable** contract with `SetError(err error)`:
+    - Enables tokens/builders to mark themselves as errored after construction
+    - Implemented in `Field` and `Table` tokens
+    - Updated `doc.go`, `README.md`, and `example_test.go` with usage examples
 
 ## Database Package (token/table)
 


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- [x] Tests written and passing (nil → valid → edge cases).  
- [ ] Tests follow `file → methods → cases` pattern with **PascalCase**.  
- [ ] Docs updated:
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
