### PR TITLE
release(v1.13.0): finalize field refinements, contracts, and docs restructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v1.13.0] - Upcoming
-
 ### Database (builder/select)
 - Added full clause support:
     - **Conditions**: `Where`, `And`, `Or` (reset, append, normalize with AND, ignore empty).
@@ -17,32 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - Invalid fields produce consistent `⛔️ Field("<expr>"): input type unsupported: <type>` errors.
     - `Debug()` and `String()` improved with ✅/⛔️ status markers.
     - `Build()` aggregates invalid fields, detects nil receiver and missing source, with clear ❌ messages.
-
-### Database (contract)
-- Introduced **BaseToken** contract (`db/contract/base_token.go`):
-    - Provides core identity and validation for all tokens
-    - Methods: `Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`
-    - Ensures `Field`, `Table`, and future tokens expose consistent state
-- Added runnable example (`ExampleBaseToken`) in `example_test.go`
-- Updated `doc.go` to include BaseToken in contract overview with normalized style
-- Updated `README.md`:
-    - Added BaseToken section with purpose, methods, and usage
-    - Streamlined layout, removed redundancy
-    - Extended philosophy with **Consistency** principle: all tokens share BaseToken
-- Extended **Errorable** contract with `SetError(err error)`:
-    - Allows tokens/builders to mark themselves as errored after construction
-    - Implemented in `Field` and `Table` tokens
-    - Updated `doc.go`, `README.md`, and `example_test.go` to demonstrate usage
-  
-### Database (token/table)
-- Introduced **Table token** to represent SQL sources in builders:
-    - Provides constructors and helpers to define tables, aliases, and raw inputs.
-    - Supports consistent rendering across dialects.
-    - Ensures validation of invalid/empty inputs with clear error reporting.
-- Added **unit tests** covering constructors, methods, and edge cases with 100% coverage.
-- Added **doc.go** with package overview and usage guidelines.
-- Added **example_test.go** with runnable examples.
-- Added **README.md** documenting purpose, design, and usage of token.Table.
 
 ### Database (token/field)
 - Refactored **Field** into dedicated subpackage `db/token/field`:
@@ -64,6 +37,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - Added `db/token/doc.go` with GoDoc overview, principles, subpackages, and roadmap.
 
 
+### Database (token/table)
+- Introduced **Table token** to represent SQL sources in builders:
+    - Provides constructors and helpers to define tables, aliases, and raw inputs.
+    - Supports consistent rendering across dialects.
+    - Ensures validation of invalid/empty inputs with clear error reporting.
+- Added **unit tests** covering constructors, methods, and edge cases with 100% coverage.
+- Added **doc.go** with package overview and usage guidelines.
+- Added **example_test.go** with runnable examples.
+- Added **README.md** documenting purpose, design, and usage of token.Table.
+
+### Database (contract)
+- Introduced **BaseToken** contract (`db/contract/base_token.go`):
+    - Provides core identity and validation for all tokens
+    - Methods: `Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`
+    - Ensures `Field`, `Table`, and future tokens expose consistent state
+- Added runnable example (`ExampleBaseToken`) in `example_test.go`
+- Updated `doc.go` to include BaseToken in contract overview with normalized style
+- Updated `README.md`:
+    - Added BaseToken section with purpose, methods, and usage
+    - Streamlined layout, removed redundancy
+    - Extended philosophy with **Consistency** principle: all tokens share BaseToken
+- Extended **Errorable** contract with `SetError(err error)`:
+    - Allows tokens/builders to mark themselves as errored after construction
+    - Implemented in `Field` and `Table` tokens
+    - Updated `doc.go`, `README.md`, and `example_test.go` to demonstrate usage
+  
 ### Common (extension/integer)
 - Introduced **integer parser**:
     - `ParseFrom(any)` converts input safely to int, rejects invalid types.
@@ -74,6 +73,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Comprehensive unit tests across Database and Common ensuring 100% coverage.
 - **README.md**, **doc.go**, and **example_test.go** updated with Conditions, Grouping, Having, Ordering, and Integer parser sections.
 - Added runnable examples in `example_test.go` demonstrating new Having clause.
+
+### Documentation
+- Root `README.md` refactored:
+  - Added **Doctrine** section (Never panic, Auditability, Strict validation, Delegation).
+  - Replaced bullet list with **capabilities table** (Modules, Features, Purpose, Status).
+  - Added status icons: ✅ Stable, 🚧 On Going, 📝 Planned.
+  - Streamlined layout: removed redundant Quickstart and developer guide links.
+- Aligned method docstrings (`String`, `Raw`, `Render`, `Debug`) with clarified audiences (UI/UX, logging, developer diagnostics, builder output).
+
 
 ## [v1.12.0](https://github.com/entiqon/entiqon/releases/tag/v1.12.0) - 2025-08-22
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@
 
 ---
 
+## 🧭 Doctrine
+- **Never panic** — always return a token or builder, errors are embedded not thrown.
+- **Auditability** — preserve user input for logs and error context.
+- **Strict validation** — invalid expressions rejected early.
+- **Delegation** — tokens own parsing/validation, builders compose them.
+
+---
+
 ## 📏 Best Practices
 
 * 🧼 Clarity over brevity — use explicit method names
@@ -40,13 +48,6 @@
 * 🧠 Tag errors with `StageToken`
 * ⚙️ Compose with safe abstractions
 * 📂 Group test methods visually
-
-## 🧠 Philosophy & Principles
-
-- **Never panic** — always returns a `*Table`, even if errored.
-- **Auditability** — preserves original input for logs.
-- **Strict enforcement** — invalid inputs are rejected immediately.
-- **Delegation** — parsing rules live in `table.New`, not in builders.
 
 ---
 

--- a/db/README.md
+++ b/db/README.md
@@ -1,54 +1,39 @@
-<h1 align="left">
-  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="82" width="82" alt=""> Database
-</h1>
-<h6 align="left">Part of the <a href="https://github.com/entiqon/entiqon">Entiqon Core</a> toolkit.</h6>
+# Database
+Part of the [Entiqon Core](https://github.com/entiqon/entiqon).
 
 ## 🌱 Overview
-
-Entiqon is a modular SQL query engine for Go focused on:
-
-* 🧱 Composable and type-safe SQL builders
-* 🔄 Dialect abstraction and pluggable formatting logic
-* 🔍 Strict validation with tagged error context
-* 🧪 Full method-based test coverage
+Entiqon/db is a modular SQL query engine for Go, designed for composable, type-safe, and auditable SQL generation.
 
 ---
 
-## 🚀 Quick Start
-
-```bash
-go get github.com/entiqon/db/v2
-```
-
-```go
-sql, args, err := builder.NewSelect().
-    From("users").
-    Where("email = ?", "test@entiqon.dev").
-    Build()
-```
+## 🧭 Doctrine
+- **Never panic** — always return a token or builder, errors are embedded not thrown.
+- **Auditability** — preserve user input for logs and error context.
+- **Strict validation** — invalid expressions rejected early.
+- **Delegation** — tokens own parsing/validation, builders compose them.
 
 ---
 
-## 📘 Developer Guides
+## 🛠 Capabilities
+## 🛠 Capabilities
 
-### Architecture & Concepts
-
-- [Builder Architecture](../docs/dev/builder/builder_guide.md) — Dialects, StageToken, ParamBinder integration
-
-### Builders
-
-- [SelectBuilder](../docs/dev/builder/select_builder.md)
-- [InsertBuilder](../docs/dev/builder/insert_builder.md)
-- [UpdateBuilder](../docs/dev/builder/update_builder.md)
-- [DeleteBuilder](../docs/dev/builder/delete_builder.md)
-- [UpsertBuilder](../docs/dev/builder/upsert_builder.md)
-
-### Extensions
-
-- [Custom Driver Guide](../docs/dev/core/driver/custom_driver_guide.md)
+| Module                 | Feature                | Purpose                                                                    | Status      |
+|------------------------|------------------------|----------------------------------------------------------------------------|-------------|
+| [builder](./builder)   | [insert](./builder)    | High-level SQL builder for INSERT statements                               | 📝 Planned  |
+|                        | [select](./builder)    | High-level SQL builder for SELECT statements (stable and production-ready) | ✅ Stable    |
+|                        | [update](./builder)    | High-level SQL builder for UPDATE statements                               | 📝 Planned  |
+|                        | [delete](./builder)    | High-level SQL builder for DELETE statements                               | 📝 Planned  |
+|                        | [upsert](./builder)    | High-level SQL builder for UPSERT / MERGE statements                       | 📝 Planned  |
+| [token](./token)       | [field](./token/field) | Dialect-agnostic representation of SQL fields/expressions                  | ✅ Stable    |
+|                        | [table](./token/table) | Dialect-agnostic representation of SQL tables/sources                      | 🚧 On Going |
+| [contract](./contract) | BaseToken              | Common base for tokens (shared identity, ownership, validity checks)       | 📝 Planned  |
+|                        | Clonable               | Ensures semantic cloning of tokens without mutation                        | ✅ Stable    |
+|                        | Debuggable             | Provides developer-facing diagnostics (`Debug()`)                          | ✅ Stable    |
+|                        | Rawable                | Provides generic SQL output for logging (`Raw()`)                          | ✅ Stable    |
+|                        | Renderable             | Provides dialect-aware SQL rendering (`Render()`)                          | ✅ Stable    |
+|                        | Stringable             | Provides UX-facing, human-friendly string representations (`String()`)     | ✅ Stable    |
 
 ---
 
 ## 📄 License
-
-[MIT](../LICENSE) — © Isidro Lopez / Entiqon Project
+[MIT](../LICENSE) — © Entiqon Project

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -64,9 +64,9 @@ func ExampleSelectBuilder_invalidFields() {
 	}
 	// Output:
 	// ❌ [Build] - Invalid fields:
-	//	⛔️ Field("true"): input type unsupported: bool
-	//	⛔️ Field("false"): input type unsupported: bool
-	//	⛔️ Field("123"): input type unsupported: int
+	//	⛔️ Field("true"): expr has unsupported type: bool
+	//	⛔️ Field("false"): expr has unsupported type: bool
+	//	⛔️ Field("123"): expr has unsupported type: int
 }
 
 func ExampleSelectBuilder_where() {

--- a/db/builder/select.go
+++ b/db/builder/select.go
@@ -294,10 +294,7 @@ func (b *SelectBuilder) Build() (string, error) {
 	}
 
 	if b.fields.Length() == 0 {
-		b.fields.Add(field.Field{
-			Expr:  "*",
-			IsRaw: true,
-		})
+		b.fields.Add(*field.New("*"))
 	}
 
 	parts := make([]string, 0, b.fields.Length())
@@ -305,7 +302,7 @@ func (b *SelectBuilder) Build() (string, error) {
 	for _, f := range b.fields.Items() {
 		if f.IsErrored() {
 			bad = append(bad,
-				fmt.Sprintf("⛔️ Field(%q): %v", f.Input, f.Error()))
+				fmt.Sprintf("⛔️ Field(%q): %v", f.Input(), f.Error()))
 			continue
 		}
 		parts = append(parts, f.Render())
@@ -375,10 +372,10 @@ func (b *SelectBuilder) appendFields(cols ...interface{}) *SelectBuilder {
 			if strings.Contains(v, ",") {
 				parts := splitAndTrim(v, ",")
 				for _, part := range parts {
-					b.fields.Add(*field.NewField(part))
+					b.fields.Add(*field.New(part))
 				}
 			} else {
-				b.fields.Add(*field.NewField(v))
+				b.fields.Add(*field.New(v))
 			}
 		case field.Field:
 			b.fields.Add(v)
@@ -387,10 +384,10 @@ func (b *SelectBuilder) appendFields(cols ...interface{}) *SelectBuilder {
 				b.fields.Add(*v)
 			}
 		default:
-			b.fields.Add(*field.NewField(v))
+			b.fields.Add(*field.New(v))
 		}
 	case 2, 3:
-		b.fields.Add(*field.NewField(cols...))
+		b.fields.Add(*field.New(cols...))
 	}
 	return b
 }

--- a/db/builder/select_test.go
+++ b/db/builder/select_test.go
@@ -20,7 +20,7 @@ func TestSelectBuilder(t *testing.T) {
 				sb.Fields("id")
 				fields := sb.GetFields()
 				f, _ := fields.At(0)
-				if fields.Length() != 1 || f.Expr != "id" {
+				if fields.Length() != 1 || f.Expr() != "id" {
 					t.Errorf("expected one field 'id', got %+v", fields)
 				}
 			})
@@ -37,7 +37,7 @@ func TestSelectBuilder(t *testing.T) {
 				sb := builder.NewSelect(nil).Fields("id")
 				fields := sb.GetFields()
 				f, _ := fields.At(0)
-				if fields.Length() != 1 || f.Expr != "id" {
+				if fields.Length() != 1 || f.Expr() != "id" {
 					t.Errorf("expected reset only, got %+v", fields)
 				}
 			})
@@ -48,7 +48,7 @@ func TestSelectBuilder(t *testing.T) {
 					Fields("reset") // should reset
 				fields := sb.GetFields()
 				f, _ := fields.At(0)
-				if fields.Length() != 1 || f.Expr != "reset" {
+				if fields.Length() != 1 || f.Expr() != "reset" {
 					t.Errorf("expected reset only, got %+v", fields)
 				}
 			})
@@ -64,7 +64,7 @@ func TestSelectBuilder(t *testing.T) {
 
 			t.Run("Pointer", func(t *testing.T) {
 				sb := builder.NewSelect(nil).
-					Fields(field.NewField("id")) // *token.Field
+					Fields(field.New("id")) // *token.Field
 				fields := sb.GetFields()
 				if fields.Length() != 1 {
 					t.Errorf("expected 1 field, got %d", fields.Length())
@@ -73,7 +73,7 @@ func TestSelectBuilder(t *testing.T) {
 
 			t.Run("NotPointer", func(t *testing.T) {
 				sb := builder.NewSelect(nil).
-					Fields(*field.NewField("id")) // token.Field (value)
+					Fields(*field.New("id")) // token.Field (value)
 				fields := sb.GetFields()
 				if fields.Length() != 1 {
 					t.Errorf("expected 1 field, got %d", fields.Length())
@@ -806,7 +806,7 @@ func TestSelectBuilder(t *testing.T) {
 					Source("users").
 					Fields("").
 					Build()
-				if !strings.Contains(sql, "SELECT *") {
+				if !strings.Contains(sql, "SELECT * FROM users") {
 					t.Errorf("expected to contain '*', got %v", sql)
 				}
 			})

--- a/db/token/README.md
+++ b/db/token/README.md
@@ -12,10 +12,29 @@ fragments in a dialect-agnostic way.
 These tokens are consumed by higher-level builders (e.g. `SelectBuilder`)
 to assemble safe, expressive, and auditable SQL statements.
 
-Key principles:
-- **Immutability** — tokens are never mutated after construction; cloning is explicit.
-- **Auditability** — identity aspects (input, expression, alias, owner, validation) are separated into contracts.
-- **Consistency** — all tokens share common contracts like `BaseToken`, `Renderable`, `Errorable`.
+### Doctrine
+
+- **Never panic** — constructors always return a non-nil token, even if errored.
+- **Auditability** — preserve original input for logs and debugging.
+- **Strict validation** — invalid inputs are rejected immediately with explicit errors.
+- **Delegation** — parsing rules live inside tokens, not in builders.
+- **Clarity** — contracts split responsibilities (identity, error, clone, render).
+
+---
+
+## 📜 Contracts
+
+All tokens implement a shared set of contracts:
+
+- **BaseToken** — input, expression, alias, validity
+- **Errorable** — explicit error state, never panic
+- **Clonable** — safe duplication with preserved state
+- **Rawable** — SQL-generic rendering (expr, alias, owner)
+- **Renderable** — dialect-agnostic `String()` output
+- **Stringable** — concise diagnostic/logging string
+- **Ownerable** — ownership binding (`HasOwner`, `Owner`, `SetOwner`)
+
+Each contract has its own test suite to ensure isolation and strict coverage.
 
 ---
 
@@ -23,14 +42,14 @@ Key principles:
 
 | Package            | Purpose                                                                                               |
 |--------------------|-------------------------------------------------------------------------------------------------------|
-| [`field`](./field) | Represents a column or expression in a `SELECT` clause (with aliasing, raw expressions, validation).  |
+| [`field`](./field) | Represents a column, identifier, or computed expression (with aliasing, raw expressions, validation). |
 | [`table`](./table) | Represents a SQL source (table or view) used in `FROM` / `JOIN` clauses with aliasing and validation. |
 
 ---
 
 ## 🚧 Roadmap
 
-Future tokens will include:
+Planned tokens:
 - **conditions** (WHERE / HAVING)
 - **joins** (INNER, LEFT, etc.)
 - **functions** (aggregates, JSON, custom expressions)
@@ -41,4 +60,4 @@ Contracts will progressively enforce stricter auditability across all tokens.
 
 ## 📄 License
 
-[MIT](../../LICENSE) — © Isidro Lopez / Entiqon Project
+[MIT](../../LICENSE) — © Entiqon Project

--- a/db/token/doc.go
+++ b/db/token/doc.go
@@ -3,26 +3,40 @@
 //
 // # Overview
 //
-// The token package defines building blocks such as Field and Table
-// that are consumed by higher-level builders (e.g. SelectBuilder) to
-// assemble safe, expressive, and auditable SQL statements.
+// The token package defines atomic building blocks such as Field and
+// Table. These tokens are consumed by higher-level builders (e.g.
+// SelectBuilder) to assemble safe, expressive, and auditable SQL
+// statements.
 //
-// Key principles enforced across all tokens:
-//   - Immutability: tokens are never mutated after construction;
-//     cloning is explicit.
-//   - Auditability: identity aspects (input, expression, alias, owner,
-//     validation) are separated into contracts.
-//   - Consistency: all tokens share common contracts like BaseToken,
-//     Renderable, and Errorable.
+// # Doctrine
 //
-// Subpackages
+//   - Never panic: constructors always return a non-nil token,
+//     even if errored.
+//   - Auditability: preserve original input for logs and debugging.
+//   - Strict validation: invalid inputs are rejected immediately
+//     with explicit errors.
+//   - Delegation: parsing rules live in tokens, not in builders.
+//   - Clarity: responsibilities are split into explicit contracts.
 //
-//   - field: represents a column or expression in a SELECT clause,
-//     with support for aliasing, raw expressions, validation, and
-//     diagnostics.
+// # Contracts
+//
+// All tokens implement a shared set of contracts:
+//
+//   - BaseToken   — identity (input, expression, alias, validity)
+//   - Errorable   — explicit error state, never panic
+//   - Clonable    — safe duplication with preserved state
+//   - Rawable     — SQL-generic rendering (expr, alias, owner)
+//   - Renderable  — dialect-agnostic String() output
+//   - Stringable  — concise diagnostic/logging string
+//   - Ownerable   — ownership binding (HasOwner, Owner, SetOwner)
+//
+// # Subpackages
+//
+//   - field: represents a column, identifier, or computed expression
+//     with aliasing, validation, and diagnostics.
 //
 //   - table: represents a SQL source (table or view) used in FROM /
-//     JOIN clauses, with aliasing and validation support.
+//     JOIN clauses with aliasing and validation support.
 //
 // # Roadmap
 //

--- a/db/token/field/README.md
+++ b/db/token/field/README.md
@@ -1,69 +1,75 @@
 <h1 align="left">
-  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96"> token.Field
+  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96" alt="entiqon"> Field
 </h1>
-<h6 align="left">Part of the <a href="https://github.com/entiqon/entiqon">Entiqon</a>::<span>Database</span> toolkit.</h6>
+<h6 align="left">Part of the <a href="../../../README.md">Entiqon</a> / <a href="../../README.md">Database</a> / <a href="../README.md">Token</a> toolkit.</h6>
 
+
+<h1 align="left">
+  <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="96" width="96" alt="entiqon"> Field
+</h1>
+<h6 align="left">Part of the <a href="../../../README.md">Entiqon</a> / <a href="../../README.md">Database</a> / <a href="../README.md">Token</a> toolkit.</h6>
 
 ## 📜 User Guide
 
-`token.Field` represents a **single column or expression** in a `SELECT` statement.  
+`token.Field` represents a **single column, computed expression, or subquery** in a SQL statement.
 The builder provides multiple ways to instantiate it, depending on what you want to express.
 
 ### Instantiation Rules
 
-1. **Single string** → one or more fields
-   - **Plain column**
-     ```go
-     .Fields("id")
-     // SELECT id
-     ```
-   - **Comma-separated list**
-     ```go
-     .Fields("id, name, email")
-     // SELECT id, name, email
-     ```
-   - **Aliased by space**
-     ```go
-     .Fields("id user_id")
-     // SELECT id AS user_id
-     ```
-   - **Aliased by AS keyword**
-     ```go
-     .Fields("id AS user_id")
-     // SELECT id AS user_id
-     ```
-   - **Function expression with alias**
-     ```go
-     .Fields("COUNT(id) AS row_count")
-     // SELECT COUNT(id) AS row_count
-     ```
+1. **Single string** → one field
 
-2. **Two arguments (string, string)** → field + alias
+    * **Plain column**
+
+      ```go
+      f := field.New("id")
+      // renders: id
+      ```
+    * **Aliased by space**
+
+      ```go
+      f := field.New("id user_id")
+      // renders: id AS user_id
+      ```
+    * **Aliased by AS keyword**
+
+      ```go
+      f := field.New("id AS user_id")
+      // renders: id AS user_id
+      ```
+    * **Computed expression (functions, arithmetic)**
+
+      ```go
+      f := field.New("SUM(qty * price) total")
+      // renders: SUM(qty * price) AS total
+ 
+      f = field.New("qty * price")
+      // renders: qty * price AS expr_alias_xxxxx
+      ```
+    * **Subquery**
+
+      ```go
+      f := field.New("(SELECT id FROM users) u")
+      // renders: (SELECT id FROM users) AS u
+ 
+      f = field.New("(SELECT id FROM users)")
+      // renders: (SELECT id FROM users) AS expr_alias_xxxxx
+      ```
+
+2. **Two arguments (string, string)** → expr + alias
+
    ```go
-   .Fields("id", "user_id")
-   // SELECT id AS user_id
+   f := field.New("id", "user_id")
+   // renders: id AS user_id
    ```
 
-3. **Three arguments (string, string, bool)** → raw expression with alias
+3. **Three arguments (string, string, bool)** → expr + alias + isRaw
+
    ```go
-   .Fields("COUNT(*)", "total", true)
-   // SELECT COUNT(*) AS total
+   f := field.New("COUNT(*)", "total", true)
+   // renders: COUNT(*) AS total
    ```
 
-4. **Multiple `Field` objects** → explicit choice
-   ```go
-   .Fields(
-       *token.NewField("id"),
-       *token.NewField("name"),
-   )
-   // SELECT id, name
-   ```
-
-### Things to Avoid
-
-- Don’t pass `("id", "name")` unless you mean **alias** (`id AS name`).  
-- Don’t try to concatenate raw SQL strings directly into `Fields` with multiple arguments unless you mean aliasing.  
-- Prefer explicit `token.NewField(...)` if you want to avoid ambiguity.
+> ℹ️ **Note:** Comma-separated lists like `"id, name, email"` are supported at the **SelectBuilder** level, **not** by `Field`.
 
 ---
 
@@ -71,42 +77,9 @@ The builder provides multiple ways to instantiate it, depending on what you want
 
 ### Internal Representation
 
-A `Field` has the following structure:
-
-```go
-type Field struct {
-    Input  string  // raw input as given by user
-    Expr   string  // resolved expression (alias stripped)
-    Alias  string  // optional alias
-    IsRaw  bool    // true if raw expression
-    Error  error   // set if instantiation failed
-}
-```
-
-### Lifecycle
-
-1. **Construction**  
-   - Always done through `token.NewField(...)`.  
-   - Handles all valid instantiation forms:
-     - `NewField("expr")`
-     - `NewField("expr alias")` or `NewField("expr AS alias")`
-     - `NewField("expr", "alias")`
-     - `NewField("expr", "alias", true)`
-     - `NewField(*Field)` (not allowed, use `.Clone()` instead)
-
-2. **Validation**  
-   - If input type is unsupported, `Error` is set.  
-   - If input is another `Field`, `Error` advises to use `.Clone()` instead.  
-
-3. **Rendering**  
-   - `Render()` → dialect-agnostic SQL fragment.  
-   - `IsAliased()` → true if alias is set.  
-   - `IsErrored()` → true if `Error` is non-nil.  
-   - `IsValid()` → true if no error and Expr is set.  
-
-4. **Cloning**  
-   - `Clone()` returns a deep copy, preserving `nil` if original is nil.  
-   - Prevents mutation of shared fields.
+A `Field` preserves the original input and provides strict parsing into components.
+All internal members are kept **unexported** to enforce immutability.
+They are only accessible through contract methods (`Input()`, `Expr()`, `Alias()`, etc.).
 
 ---
 
@@ -114,31 +87,49 @@ type Field struct {
 
 Two methods are provided for inspection:
 
-- **`String()`** → concise log view.  
-  - ✅ valid field:  
-    ```
-    ✅ Field("id")
-    ✅ Field("id AS user_id")
-    ```
-  - ⛔️ invalid field:  
-    ```
-    ⛔️ Field("true"): input type unsupported: bool
-    ⛔️ Field(<nil>): wrong initialization
-    ```
+* **`String()`** → concise log/SQL view.
 
-- **`Debug()`** → detailed diagnostic view.  
-  - ✅ valid field:  
-    ```
-    ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
-    ```
-  - ⛔️ invalid field:  
-    ```
-    ⛔️ Field("false"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
-    ```
+    * ✅ valid field:
+
+      ```
+      id
+      id AS user_id
+      ```
+    * ⛔️ invalid field:
+
+      ```
+      ⛔️ Field(""): empty expression is not allowed
+      ```
+
+* **`Debug()`** → detailed diagnostic view.
+
+    * ✅ valid field:
+
+      ```
+      Field(Input="COUNT(*) AS total", Expr="COUNT(*)", Alias="total", Raw=true, Err=<nil>)
+      ```
+    * ⛔️ invalid field:
+
+      ```
+      ⛔️ Field("false"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
+      ```
 
 ---
 
-## ✅ Summary
+## ✅ Contracts
 
-- **Users**: treat `Field` as *one column or expression*. Use `.Fields(...)` safely with the instantiation rules.  
-- **Contributors**: enforce immutability, strict parsing in `NewField`, and clear reporting through `String()` and `Debug()`.
+`Field` implements the shared **token contracts**:
+
+* `BaseToken` → input, expr, alias, validity
+* `Errorable` → explicit error state
+* `Clonable` → safe deep copies
+* `Rawable` → SQL-generic rendering (expr, alias, owner)
+* `Renderable` → dialect-agnostic SQL fragment (`String()`)
+* `Stringable` → concise logging
+* `Ownerable` → ownership binding (`HasOwner`, `Owner`, `SetOwner`)
+
+---
+
+## 📄 License
+
+[MIT](../../LICENSE) — © Entiqon Project

--- a/db/token/field/contract.go
+++ b/db/token/field/contract.go
@@ -66,7 +66,7 @@ type Token interface {
 	//
 	// Must be called only when HasOwner() returns true; otherwise the result
 	// is undefined.
-	Owner() string
+	Owner() *string
 
 	// SetOwner assigns or clears the owning table name (or alias).
 	//
@@ -77,5 +77,4 @@ type Token interface {
 }
 
 // Ensure *Field implements Token at compile time.
-// (commented until full implementation is ready)
-// var _ Token = (*Field)(nil)
+var _ Token = (*Field)(nil)

--- a/db/token/field/doc.go
+++ b/db/token/field/doc.go
@@ -1,4 +1,4 @@
-// Package token defines the low-level primitives used by the SQL builder.
+// Package field defines the low-level primitives used by the SQL builder.
 //
 // # Overview
 //
@@ -14,24 +14,24 @@
 // A Field represents a single column or expression in a SELECT query.
 // It can optionally have an alias and may be marked as raw.
 //
-// Field supports multiple instantiation forms through NewField:
+// Field supports multiple instantiation forms through New:
 //
-//   - NewField("expr")
+//   - New("expr")
 //     A single expression, e.g. "id"
 //
-//   - NewField("expr alias")
+//   - New("expr alias")
 //     Expression with alias, parsed by space, e.g. "id user_id"
 //
-//   - NewField("expr AS alias")
+//   - New("expr AS alias")
 //     Expression with alias using AS, e.g. "id AS user_id"
 //
-//   - NewField("expr", "alias")
+//   - New("expr", "alias")
 //     Expression and alias provided separately
 //
-//   - NewField("expr", "alias", true)
+//   - New("expr", "alias", true)
 //     Expression and alias with IsRaw set explicitly
 //
-//   - NewField(*Field)
+//   - New(*Field)
 //     Disallowed: users must call Clone() instead
 //
 // # Field Behavior
@@ -47,6 +47,9 @@
 //   - Render: returns a dialect-agnostic SQL fragment
 //   - Clone: produces a deep copy
 //   - IsAliased, IsErrored, IsValid: convenience checks
+//   - HasOwner: reports whether the field is qualified by a table name or alias
+//   - Owner: returns the owning table name (or alias) if one is set
+//   - SetOwner: assigns or clears the owning table name (passing nil clears it)
 //
 // # Usage Example
 //

--- a/db/token/field/example_test.go
+++ b/db/token/field/example_test.go
@@ -6,74 +6,141 @@ import (
 	"github.com/entiqon/entiqon/db/token/field"
 )
 
-// ExampleNewField demonstrates the basic instantiation forms of Field.
-func ExampleNewField() {
-	// Single expression
-	f1 := field.NewField("id")
+//
+// BaseToken contract
+//
 
-	// Expression with alias (space-separated)
-	f2 := field.NewField("id user_id")
-
-	// Expression with alias (AS keyword)
-	f3 := field.NewField("COUNT(*) AS total")
-
-	// Expression and alias separately
-	f4 := field.NewField("name", "username")
-
-	// Expression and alias with raw flag
-	f5 := field.NewField("JSON_EXTRACT(data, '$.name')", "extracted", true)
-
-	fmt.Println(f1.Render())
-	fmt.Println(f2.Render())
-	fmt.Println(f3.Render())
-	fmt.Println(f4.Render())
-	fmt.Println(f5.Render())
-
-	// Output:
-	// id
-	// id AS user_id
-	// COUNT(*) AS total
-	// name AS username
-	// JSON_EXTRACT(data, '$.name') AS extracted
+// ExampleField_Input shows that Input() preserves the original input string.
+func ExampleField_Input() {
+	f := field.New("SUM(qty) total")
+	fmt.Println(f.Input())
+	// Output: SUM(qty) total
 }
 
-// ExampleField_clone demonstrates the Clone method.
-func ExampleField_clone() {
-	original := field.NewField("id", "user_id")
-	clone := original.Clone()
-
-	fmt.Println(original.Render())
-	fmt.Println(clone.Render())
-	fmt.Println(original == clone) // should be false, deep copy
-
-	// Output:
-	// id AS user_id
-	// id AS user_id
-	// false
+// ExampleField_Expr shows Expr() returns the parsed expression without alias.
+func ExampleField_Expr() {
+	f := field.New("SUM(qty) total")
+	fmt.Println(f.Expr())
+	// Output: SUM(qty)
 }
 
-// ExampleField_invalid demonstrates invalid field creation.
-func ExampleField_invalid() {
-	// Passing an unsupported type (e.g. bool) results in an errored field.
-	f := field.NewField(true)
-
-	if f.IsErrored() {
-		fmt.Println(f.String()) // concise log view
-		fmt.Println(f.Debug())  // detailed diagnostic view
-	}
-
-	// Output:
-	// ⛔️ Field("true"): input type unsupported: bool
-	// ⛔️ Field("true"): [raw: false, aliased: false, errored: true] – input type unsupported: bool
+// ExampleField_Alias shows Alias() returns the parsed alias.
+func ExampleField_Alias() {
+	f := field.New("SUM(qty) total")
+	fmt.Println(f.Alias())
+	// Output: total
 }
 
-// ExampleField_debug demonstrates valid fields with Debug output.
-func ExampleField_debug() {
-	f := field.NewField("COUNT(*) AS total")
-	fmt.Println(f.String())
+// ExampleField_IsAliased shows IsAliased() is true if alias is set.
+func ExampleField_IsAliased() {
+	f := field.New("SUM(qty) total")
+	fmt.Println(f.IsAliased())
+	// Output: true
+}
+
+// ExampleField_IsRaw shows IsRaw() is true for computed expressions.
+func ExampleField_IsRaw() {
+	f := field.New("SUM(qty) total")
+	fmt.Println(f.IsRaw())
+	// Output: true
+}
+
+// ExampleField_IsValid shows IsValid() reports validity.
+func ExampleField_IsValid() {
+	f := field.New("id")
+	fmt.Println(f.IsValid())
+	// Output: true
+}
+
+//
+// Errorable contract
+//
+
+// ExampleField_Error shows Error() returns nil for valid fields and non-nil for invalid ones.
+func ExampleField_Error() {
+	f := field.New("")
+	fmt.Println(f.Error())
+	// Output: empty expression is not allowed
+}
+
+// ExampleField_IsErrored shows IsErrored() is true when the field has an error.
+func ExampleField_IsErrored() {
+	f := field.New("")
+	fmt.Println(f.IsErrored())
+	// Output: true
+}
+
+//
+// Token (ownership) contract
+//
+
+// ExampleField_HasOwner shows HasOwner() reports if a field is bound to a table.
+func ExampleField_HasOwner() {
+	f := field.New("id")
+	fmt.Println(f.HasOwner())
+	// Output: false
+}
+
+// ExampleField_Owner shows Owner() returns the bound owner if set.
+func ExampleField_Owner() {
+	f := field.NewWithTable("users", "id")
+	fmt.Println(*f.Owner())
+	// Output: users
+}
+
+// ExampleField_SetOwner shows SetOwner() attaches a table owner.
+func ExampleField_SetOwner() {
+	f := field.New("id")
+	owner := "orders"
+	f.SetOwner(&owner)
+	fmt.Println(*f.Owner())
+	// Output: orders
+}
+
+//
+// Clonable contract
+//
+
+// ExampleField_Clone shows Clone() returns a deep copy of the field.
+func ExampleField_Clone() {
+	orig := field.New("id user_id")
+	cl := orig.Clone()
+	fmt.Println(cl.Expr(), cl.Alias(), cl == orig)
+	// Output: id user_id false
+}
+
+//
+// Debugging and logging
+//
+
+// ExampleField_Debug shows Debug() returns a detailed diagnostic view.
+func ExampleField_Debug() {
+	f := field.New("COUNT(*) AS total")
 	fmt.Println(f.Debug())
+	// Output: ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
+}
 
-	// Output:
-	// ✅ Field("COUNT(*) AS total")
-	// ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
+// ExampleField_String shows String() returns concise logging output.
+func ExampleField_String() {
+	f := field.New("")
+	fmt.Println(f.String())
+	// Output: ⛔ Field(""): empty expression is not allowed
+}
+
+//
+// Rawable and Renderable contracts
+//
+
+// ExampleField_Raw shows Raw() returns SQL-generic rendering.
+func ExampleField_Raw() {
+	f := field.New("SUM(qty)", "total", true)
+	fmt.Println(f.Raw())
+	// Output: SUM(qty) AS total
+}
+
+// ExampleField_Render shows Render() produces dialect-agnostic SQL.
+func ExampleField_Render() {
+	f := field.NewWithTable("users", "id", "user_id")
+	fmt.Println(f.Render())
+	// Output: users.id AS user_id
 }

--- a/db/token/field/field_test.go
+++ b/db/token/field/field_test.go
@@ -4,7 +4,6 @@ package field_test
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -13,379 +12,477 @@ import (
 
 func TestField(t *testing.T) {
 	t.Run("Constructors", func(t *testing.T) {
-		t.Run("NoInputs", func(t *testing.T) {
-			f := field.NewField()
-			if f == nil || f.Expr != "" || f.Alias != "" {
-				t.Errorf("expected empty Field, got %+v", f)
-			}
-		})
-
-		t.Run("Expr", func(t *testing.T) {
-			t.Run("Field", func(t *testing.T) {
-				src := field.NewField("col1")
-				f := field.NewField(src)
-				if f.Error() == nil {
-					t.Errorf("expected error about Clone, got %+v", f.Error())
+		t.Run("New", func(t *testing.T) {
+			t.Run("InvalidCall", func(t *testing.T) {
+				f := field.New()
+				if f == nil {
+					t.Fatal("expected non-nil Field, got nil")
+				}
+				if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty input is not allowed") {
+					t.Errorf("expected error 'empty input is not allowed', got %v", f.Error())
 				}
 			})
 
-			t.Run("IsRaw", func(t *testing.T) {
+			t.Run("StarField", func(t *testing.T) {
+				f := field.New("*")
+				if f == nil {
+					t.Fatal("expected non-nil Field, got nil")
+				}
+				got := f.String()
+				if got != "✅ Field(\"*\")" {
+					t.Errorf("expected ✅ Field(\"*\"), got %v", got)
+				}
 
-				t.Run("WithOperator", func(t *testing.T) {
-					operators := []string{"||", "+", "-", "*", "/"}
-					for _, op := range operators {
-						expr := fmt.Sprintf("col1 %s col2", op)
-						f := field.NewField(expr)
-						if !f.IsRaw {
-							t.Errorf("expected IsRaw = true for expr %q, got false", expr)
+				f = field.New("*", "alias")
+				got = f.String()
+				if f.Error() == nil || got != "⛔ Field(\"*\"): '*' cannot be aliased or raw" {
+					t.Errorf("expected ⛔ Field(\"*\"): '*' cannot be aliased or raw, got %v", got)
+				}
+			})
+
+			t.Run("1-arg", func(t *testing.T) {
+				t.Run("InvalidCall", func(t *testing.T) {
+					f := field.New("")
+					if f == nil && f.Error() == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty expr") {
+						t.Errorf("expected error contains 'empty expr is not allowed', got %v", f.Error())
+					}
+					f = field.New(123)
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "expr has unsupported type") {
+						t.Errorf("expected error contains 'expr has unsupported type', got %v", f.Error())
+					}
+					f = field.New(field.New("id"))
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "unsupported type: Field") {
+						t.Errorf("expected error contains 'unsupported type: Field', got %v", f.Error())
+					}
+				})
+
+				t.Run("Valid", func(t *testing.T) {
+					t.Run("Default", func(t *testing.T) {
+						f := field.New("id")
+						if f.Error() != nil {
+							t.Errorf("expected error 'nil', got %v", f.Error())
 						}
-					}
-				})
+					})
 
-				t.Run("WithParenthesis", func(t *testing.T) {
-					src := field.NewField("(col1 || '-' || col2)", " mixed")
-					f := field.NewField(src)
-					if f.Error() == nil {
-						t.Errorf("expected error about Clone, got %+v", f.Error())
-					}
-				})
+					t.Run("InlineAlias", func(t *testing.T) {
+						f := field.New("id as user_id")
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						f = field.New("(qty * price * discount) total")
+						if f.Expr() != "(qty * price * discount)" || f.Alias() != "total" {
+							t.Errorf("expected '(qty * price * discount)' AS total, got %q AS %q", f.Expr(), f.Alias())
+						}
+						f = field.New("(qty * price * discount) as total")
+						if f.Expr() != "(qty * price * discount)" || f.Alias() != "total" {
+							t.Errorf("expected '(qty * price * discount)' AS total, got %q AS %q", f.Expr(), f.Alias())
+						}
+					})
 
-				t.Run("WithAliasRules", func(t *testing.T) {
-					tests := []struct {
-						name        string
-						input       string
-						expectErr   bool
-						expectRaw   bool
-						expectAlias string // expected alias if not error
-					}{
-						{
-							name:        "NoAliasAutoGenerate",
-							input:       "col1 || '-' || col2",
-							expectErr:   false,
-							expectRaw:   true,
-							expectAlias: "",
-						},
-						{
-							name:        "ExplicitAS",
-							input:       "col1 || '-' || col2 AS full_name",
-							expectErr:   false,
-							expectRaw:   true,
-							expectAlias: "full_name",
-						},
-						{
-							name:      "SpaceAliasError",
-							input:     "col1 || '-' || col2 full_name",
-							expectErr: true,
-							expectRaw: true,
-						},
-						{
-							name:        "ComplexExprNoAlias",
-							input:       "(1*rate(principal-balance))",
-							expectErr:   false,
-							expectRaw:   true,
-							expectAlias: "",
-						},
-						{
-							name:        "ComplexExprWithAS",
-							input:       "(1*rate(principal-balance)) AS calc_rate",
-							expectErr:   false,
-							expectRaw:   true,
-							expectAlias: "calc_rate",
-						},
-						{
-							name:      "ComplexExprWithSpaceAliasError",
-							input:     "(1*rate(principal-balance)) calc_rate",
-							expectErr: true,
-							expectRaw: true,
-						},
-					}
-
-					for _, tt := range tests {
-						t.Run(tt.name, func(t *testing.T) {
-							f := field.NewField(tt.input)
-
-							if tt.expectErr {
-								if f.Error() == nil {
-									t.Errorf("expected error, got nil")
-								}
-								return
-							}
-
-							if f.Error() != nil {
-								t.Errorf("unexpected error: %v", f.Error())
-							}
-
-							if f.IsRaw != tt.expectRaw {
-								t.Errorf("expected IsRaw=%v, got %v", tt.expectRaw, f.IsRaw)
-							}
-
-							if tt.expectAlias != "" {
-								if f.Alias != tt.expectAlias {
-									t.Errorf("expected alias %q, got %q", tt.expectAlias, f.Alias)
-								}
-							} else {
-								if !strings.HasPrefix(f.Alias, "raw_expr_") {
-									t.Errorf("expected auto-generated alias to start with raw_expr_, got %q", f.Alias)
-								}
-								if len(f.Alias) != len("raw_expr_")+6 {
-									t.Errorf("expected alias length %d, got %d", len("raw_expr_")+6, len(f.Alias))
-								}
-							}
-						})
-					}
-				})
-
-				t.Run("HasTrailingAliasWithoutAS", func(t *testing.T) {
-					cases := []struct {
-						Name     string
-						Expr     string
-						Expected bool
-					}{
-						{
-							Name:     "ExplicitAS",
-							Expr:     "col1 || '-' || col2 AS full_name",
-							Expected: false,
-						},
-						{
-							Name:     "SingleToken",
-							Expr:     "col1",
-							Expected: false,
-						},
-						{
-							Name:     "PenultimateOperator",
-							Expr:     "col1 || col2",
-							Expected: false,
-						},
-						{
-							Name:     "AliasWithoutAS",
-							Expr:     "col1 full_name",
-							Expected: true,
-						},
-						{
-							Name:     "NonIdentifierLastToken",
-							Expr:     "col1 'abc'",
-							Expected: false,
-						},
-					}
-
-					for _, c := range cases {
-						t.Run(c.Name, func(t *testing.T) {
-							got := field.HasTrailingAliasWithoutAS(c.Expr)
-							if got != c.Expected {
-								t.Errorf("expected %v, got %v", c.Expected, got)
-							}
-						})
-					}
+					t.Run("Computed", func(t *testing.T) {
+						f := field.New("SUM(qty * price * discount) as total")
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						if f.Expr() != "SUM(qty * price * discount)" || f.Alias() != "total" {
+							t.Errorf("expected 'SUM(qty * price * discount)' AS total, got %q AS %q", f.Expr(), f.Alias())
+						}
+						f = field.New("SUM(qty * price * discount) total")
+						if f.Expr() != "SUM(qty * price * discount)" || f.Alias() != "total" {
+							t.Errorf("expected 'SUM(qty * price * discount)' AS total, got %q AS %q", f.Expr(), f.Alias())
+						}
+						f = field.New("SUM(qty * price * discount)")
+						if f.Expr() != "SUM(qty * price * discount)" || !strings.Contains(f.Alias(), "expr_alias_") {
+							t.Errorf("expected 'SUM(qty * price * discount)' with auto alias, got %q AS %q", f.Expr(), f.Alias())
+						}
+						f = field.New("col1 || '-' || col2")
+						if f.Expr() != "col1 || '-' || col2" || !strings.Contains(f.Alias(), "expr_alias_") {
+							t.Errorf("expected \"col1 || '-' || col2\" with alias like \"expr_alias_\", got %q AS %q", f.Expr(), f.Alias())
+						}
+					})
 				})
 			})
 
-			t.Run("UnsupportedType", func(t *testing.T) {
-				f := field.NewField(123)
-				if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
-					t.Errorf("expected unsupported expr type error, got %+v", f.Error())
+			t.Run("2-args", func(t *testing.T) {
+				t.Run("InvalidCall", func(t *testing.T) {
+					f := field.New("field", 123)
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "alias has unsupported type") {
+						t.Errorf("expected error 'alias has unsupported type', got %v", f.Error())
+					}
+					f = field.New("field", "")
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty alias is not allowed") {
+						t.Errorf("expected error 'empty alias is not allowed', got %v", f.Error())
+					}
+				})
+
+				t.Run("Valid", func(t *testing.T) {
+					t.Run("Default", func(t *testing.T) {
+						f := field.New("field", "alias")
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						if f.Error() != nil {
+							t.Fatal("expected error to be nil, got non-nil")
+						}
+					})
+
+					t.Run("Computed", func(t *testing.T) {
+						f := field.New("(qty * price * discount)", "total")
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						if f.Error() != nil {
+							t.Fatal("expected error to be nil, got non-nil")
+						}
+					})
+				})
+			})
+
+			t.Run("3-args", func(t *testing.T) {
+				t.Run("InvalidCall", func(t *testing.T) {
+					f := field.New("field", 123, true)
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "alias has unsupported type") {
+						t.Errorf("expected error 'alias has unsupported type', got %v", f.Error())
+					}
+					f = field.New("field", "", true)
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty alias is not allowed") {
+						t.Errorf("expected error 'empty alias is not allowed', got %v", f.Error())
+					}
+					f = field.New("field", "alias", 123)
+					if f == nil {
+						t.Fatal("expected non-nil Field, got nil")
+					}
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "isRaw has invalid type") {
+						t.Errorf("expected error 'isRaw has invalid type', got %v", f.Error())
+					}
+				})
+
+				t.Run("Valid", func(t *testing.T) {
+					t.Run("Default", func(t *testing.T) {
+						f := field.New("field", "alias", false)
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						if f.Error() != nil {
+							t.Fatal("expected error to be nil, got non-nil")
+						}
+					})
+
+					t.Run("Computed", func(t *testing.T) {
+						f := field.New("(qty * price * discount)", "total", true)
+						if f == nil {
+							t.Fatal("expected non-nil Field, got nil")
+						}
+						if f.Error() != nil {
+							t.Fatal("expected error to be nil, got non-nil")
+						}
+					})
+				})
+			})
+
+			t.Run("n-args", func(t *testing.T) {
+				f := field.New("field", "alias", false, 1234)
+				if f == nil {
+					t.Fatal("expected non-nil Field, got nil")
+				}
+				if f.Error() == nil || f.Error().Error() != "invalid Field constructor signature" {
+					t.Errorf("expected error 'invalid Field constructor signature', got %v", f.Error())
+				}
+			})
+		})
+
+		t.Run("NewWithTable", func(t *testing.T) {
+			t.Run("InvalidCall", func(t *testing.T) {
+				f := field.NewWithTable("", "SUM(qty * price)", "line_total")
+				if f == nil {
+					t.Fatal("expected non-nil Field, got nil")
+				}
+				if f.Error() == nil || f.Error().Error() != "owner is empty" {
+					t.Errorf("expected error to be non-nil, got %v", f.Error())
 				}
 			})
 
+			t.Run("Valid", func(t *testing.T) {
+				f := field.NewWithTable("order", "SUM(qty * price)", "line_total", true)
+				if f == nil {
+					t.Fatal("expected non-nil Field, got nil")
+				}
+				if f.Error() != nil {
+					t.Errorf("expected error to be nil, got %v", f.Error())
+				}
+				if !f.HasOwner() || *f.Owner() != "order" {
+					t.Errorf("expected owner 'order', got %v", f.Owner())
+				}
+			})
 		})
-
-		t.Run("OneArgSimpleExpr", func(t *testing.T) {
-			f := field.NewField("col1")
-			if f.Expr != "col1" || f.Alias != "" || f.IsRaw {
-				t.Errorf("unexpected field %+v", f)
-			}
-		})
-
-		t.Run("OneArgWithAS", func(t *testing.T) {
-			f := field.NewField("col1 AS c1")
-			if f.Expr != "col1" || f.Alias != "c1" {
-				t.Errorf("expected expr=col1 alias=c1, got %+v", f)
-			}
-		})
-
-		t.Run("OneArgWithSpaceAlias", func(t *testing.T) {
-			f := field.NewField("col1 c1")
-			if f.Expr != "col1" || f.Alias != "c1" {
-				t.Errorf("expected expr=col1 alias=c1, got %+v", f)
-			}
-		})
-
-		t.Run("TwoArgsExprAlias", func(t *testing.T) {
-			f := field.NewField("col1", "alias1")
-			if f.Expr != "col1" || f.Alias != "alias1" {
-				t.Errorf("expected expr=col1 alias=alias1, got %+v", f)
-			}
-		})
-
-		t.Run("TwoArgsAliasUnsupportedType", func(t *testing.T) {
-			f := field.NewField("col1", 123)
-			if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
-				t.Errorf("expected unsupported alias type error, got %+v", f.Error())
-			}
-		})
-
-		t.Run("ThreeArgsValid", func(t *testing.T) {
-			f := field.NewField("input1", "alias1", true)
-			if f.Raw() != "input1 AS alias1" || f.Expr != "input1" || f.Alias != "alias1" || !f.IsRaw {
-				t.Errorf("unexpected field %+v", f)
-			}
-		})
-
-		t.Run("ThreeArgsAliasWrongType", func(t *testing.T) {
-			f := field.NewField("input1", 123, true)
-			if f.Error() == nil || !strings.Contains(f.Error().Error(), "input type unsupported: int") {
-				t.Errorf("expected unsupported type error, got %+v", f.Error())
-			}
-		})
-
-		t.Run("ThreeArgsIsRawWrongType", func(t *testing.T) {
-			f := field.NewField("input1", "alias1", "yes")
-			if f.Error() == nil || f.Error().Error() != "isRaw must be a bool" {
-				t.Errorf("expected isRaw must be a bool error, got %+v", f.Error())
-			}
-		})
-
-		t.Run("InvalidSignatureFourArgs", func(t *testing.T) {
-			// expr, alias, isRaw
-			f1 := field.NewField("col1", "alias1", true, "yes")
-			if f1.Error() == nil || f1.Error().Error() != "invalid NewField signature" {
-				t.Errorf("expected invalid NewField signature error, got %+v", f1.Error())
-			}
-		})
-
 	})
 
-	t.Run("Methods", func(t *testing.T) {
-		t.Run("Clone", func(t *testing.T) {
-			t.Run("Success", func(t *testing.T) {
-				orig := &field.Field{Input: "i", Expr: "e", Alias: "a", IsRaw: true}
-				cl := orig.Clone()
-				if cl == orig {
-					t.Fatal("expected different pointer")
-				}
-				if *cl != *orig {
-					t.Errorf("clone differs: got %+v, want %+v", *cl, *orig)
-				}
-			})
-
-			t.Run("NilReceiver", func(t *testing.T) {
-				var f *field.Field = nil
-				got := f.Clone()
-				if got != nil {
-					t.Errorf("cloned field = %+v, want %+v", got, f)
-				}
-			})
-		})
-
-		t.Run("IsAliased", func(t *testing.T) {
-			cases := []struct {
-				alias string
-				want  bool
-			}{
-				{"", false},
-				{"  ", false},
-				{"alias", true},
-				{"ALIAS", true},
-			}
-			for _, tc := range cases {
-				f := field.Field{Alias: tc.alias}
-				got := f.IsAliased()
-				if got != tc.want {
-					t.Errorf("IsAliased() alias=%q got %v, want %v", tc.alias, got, tc.want)
-				}
-			}
-		})
-
-		t.Run("IsErrored", func(t *testing.T) {
-			f := field.Field{Expr: "field", Alias: "f"}
-			if f.IsErrored() {
-				t.Error("expected IsErrored false when Error is nil")
-			}
-			f.SetError(errors.New("some error"))
-			if !f.IsErrored() {
-				t.Error("expected IsErrored true when Error set")
-			}
-		})
-
-		t.Run("IsValid", func(t *testing.T) {
-			f := field.Field{Expr: "field", Alias: "f"}
+	t.Run("Contracts", func(t *testing.T) {
+		t.Run("BaseToken", func(t *testing.T) {
+			f := field.New("SUM(qty) total")
 			if !f.IsValid() {
-				t.Error("expected IsValid true when no Error and Expr non-empty")
+				t.Error("expected IsValid() to be true")
 			}
-			f.SetError(errors.New("some error"))
+			if f.Input() != "SUM(qty) total" {
+				t.Errorf("expected 'SUM(qty)', got %q", f.Input())
+			}
+			if f.Expr() != "SUM(qty)" {
+				t.Errorf("expected 'SUM(qty)', got %q", f.Expr())
+			}
+			if !f.IsAliased() || f.Alias() != "total" {
+				t.Errorf("expected 'total', got %q", f.Alias())
+			}
+			if !f.IsRaw() {
+				t.Errorf("expected 'isRaw', got %t", f.IsRaw())
+			}
+
+			// Identifier case
+			f = field.New("id")
+			if f.IsRaw() {
+				t.Errorf("expected IsRaw() to be false, got %t", f.IsRaw())
+			}
+			if f.IsAliased() {
+				t.Errorf("expected IsAliased() to be false, got true with alias %q", f.Alias())
+			}
+
+			// Invalid field
+			f = field.New("")
 			if f.IsValid() {
-				t.Error("expected IsValid false when Error set")
-			}
-			f = field.Field{Expr: "  "}
-			if f.IsValid() {
-				t.Error("expected IsValid false when Expr is empty")
-			}
-			f = field.Field{Expr: "!@#$%^&*()"}
-			if f.IsValid() {
-				t.Error("expected IsValid false when derived Name is empty")
+				t.Error("expected IsValid() to be false")
 			}
 		})
 
-		t.Run("Name", func(t *testing.T) {
-			cases := []struct {
-				alias string
-				expr  string
-				want  string
-			}{
-				{"", "fieldName", "fieldname"},
-				{"ALIAS", "ignored", "alias"},
-				{"Id", "some_expr", "id"},
-				{"", "Expr_With_123", "exprwith123"},
+		t.Run("Token", func(t *testing.T) {
+			// Valid field, no owner initially
+			f := field.New("SUM(qty) total")
+			if f.HasOwner() {
+				t.Error("expected HasOwner() to be false")
 			}
-			for _, tc := range cases {
-				f := field.Field{Alias: tc.alias, Expr: tc.expr}
-				got := f.Name()
-				if got != tc.want {
-					t.Errorf("Name() alias=%q expr=%q got %q, want %q", tc.alias, tc.expr, got, tc.want)
-				}
+			if f.Owner() != nil {
+				t.Errorf("expected nil, got %v", *f.Owner())
+			}
+
+			owner := "orders"
+			f.SetOwner(&owner)
+			if !f.HasOwner() || *f.Owner() != owner {
+				t.Error("expected HasOwner() to be true")
+			}
+
+			// Invalid field, owner should still be nil
+			bad := field.New("")
+			if bad.HasOwner() {
+				t.Error("expected HasOwner() to be false on invalid field")
+			}
+			if bad.Owner() != nil {
+				t.Errorf("expected nil owner on invalid field, got %v", *bad.Owner())
 			}
 		})
 
-		t.Run("Raw", func(t *testing.T) {
-			f := field.Field{Expr: "field"}
-			if got := f.Raw(); got != "field" {
-				t.Errorf("Raw() without alias got %q, want %q", got, "field")
+		t.Run("Clonable", func(t *testing.T) {
+			orig := field.New("SUM(qty)", "total", true)
+			cl := orig.Clone()
+			if cl == orig {
+				t.Fatal("expected different pointer")
 			}
-			f.Alias = "alias"
-			if got := f.Raw(); got != "field AS alias" {
-				t.Errorf("Raw() with alias got %q, want %q", got, "field AS alias")
+			if cl.Input() != orig.Input() || cl.Expr() != orig.Expr() ||
+				cl.Alias() != orig.Alias() || cl.IsRaw() != orig.IsRaw() {
+				t.Errorf("clone mismatch: got %+v, want %+v", cl, orig)
+			}
+
+			// clone preserves error state
+			if field.New("").Clone().Error() == nil {
+				t.Error("expected error to be preserved in clone")
+			}
+
+			owner := "orders"
+			orig.SetOwner(&owner)
+			cl = orig.Clone()
+			if cl.Owner() == nil {
+				t.Error("expected clone to preserve owner, got nil")
+			}
+			if cl.Owner() == &owner {
+				t.Error("expected clone to deep-copy owner, got same pointer")
 			}
 		})
 
-		t.Run("Render", func(t *testing.T) {
-			f := field.Field{Expr: "LOWER(x)"}
-			if got, want := f.Render(), "LOWER(x)"; got != want {
-				t.Errorf("Render() got %q, want %q", got, want)
+		t.Run("Debuggable", func(t *testing.T) {
+			f := field.New("id user_id")
+			if out := f.Debug(); !strings.Contains(out, "id") || !strings.Contains(out, "user_id") {
+				t.Errorf("unexpected Debug output: %q", out)
 			}
-			f = field.Field{Expr: "LOWER(x)", Alias: "id"}
-			if got, want := f.Render(), "LOWER(x) AS id"; got != want {
-				t.Errorf("Render() got %q, want %q", got, want)
-			}
-			f = field.Field{Expr: "created_at", Alias: "  ts  "}
-			if got, want := f.Render(), "created_at AS ts"; got != want {
-				t.Errorf("Render() trims alias spaces got %q, want %q", got, want)
+
+			// invalid case: should surface the error
+			bad := field.New("")
+			if out := bad.Debug(); !strings.Contains(out, "error") {
+				t.Errorf("expected Debug() to mention error, got %q", out)
 			}
 		})
 
-		t.Run("String", func(t *testing.T) {
-			f := field.Field{Expr: "field", Alias: ""}
-			got := f.String()
-			if !strings.HasPrefix(got, "✅ Field(") {
-				t.Errorf("String() no alias got %q, want prefix %q", got, "✅ Field(")
+		t.Run("Errorable", func(t *testing.T) {
+			// Valid field → no error
+			f := field.New("id")
+			if f.Error() != nil {
+				t.Errorf("expected no error, got %v", f.Error())
 			}
-			f.Alias = "Alias"
-			got = f.String()
-			if !strings.Contains(got, "field AS Alias") {
-				t.Errorf("String() with alias got %q, want alias: true", got)
+			if f.IsErrored() {
+				t.Error("expected IsErrored() to be false")
 			}
-			f.SetError(errors.New("some error"))
-			got = f.String()
-			if !strings.Contains(got, "⛔️") || !strings.Contains(got, "some error") {
-				t.Errorf("String() errored got %q, want icon and error message", got)
+
+			// Invalid field → error set automatically
+			bad := field.New("")
+			if bad.Error() == nil || !bad.IsErrored() {
+				t.Error("expected error to be non-nil and IsErrored() true")
+			}
+
+			// Manual SetError
+			f.SetError(errors.New("forced error"))
+			if f.Error() == nil || f.Error().Error() != "forced error" {
+				t.Errorf("expected 'forced error', got %v", f.Error())
+			}
+			if !f.IsErrored() {
+				t.Error("expected IsErrored() to be true after SetError")
+			}
+		})
+
+		t.Run("Rawable", func(t *testing.T) {
+			// Identifier
+			f := field.New("id")
+			if got := f.Raw(); got != "id" {
+				t.Errorf("expected Raw() 'id', got %q", got)
+			}
+
+			// With table owner
+			f = field.NewWithTable("users", "id")
+			if got := f.Raw(); got != "users.id" {
+				t.Errorf("expected Raw() 'users.id', got %q", got)
+			}
+
+			// Computed expression with alias
+			f = field.New("SUM(qty)", "total", true)
+			if got := f.Raw(); got != "SUM(qty) AS total" {
+				t.Errorf("expected Raw() 'SUM(qty) AS total', got %q", got)
+			}
+
+			// Computed expression with alias and owner → owner should be ignored
+			f = field.NewWithTable("orders", "SUM(qty)", "total", true)
+			if got := f.Raw(); got != "SUM(qty) AS total" {
+				t.Errorf("expected Raw() 'SUM(qty) AS total' (owner ignored), got %q", got)
+			}
+
+			// Subquery with alias
+			f = field.New("(SELECT id FROM users) sub")
+			if got := f.Raw(); got != "(SELECT id FROM users) AS sub" {
+				t.Errorf("expected Raw() '(SELECT id FROM users) AS sub', got %q", got)
+			}
+
+			// Subquery with alias and owner
+			f = field.NewWithTable("t", "(SELECT id FROM users)", "u", true)
+			if got := f.Raw(); got != "(SELECT id FROM users) AS u" {
+				t.Errorf("expected Raw() '(SELECT id FROM users) AS u', got %q", got)
+			}
+
+			// Invalid field → resolution is empty
+			bad := field.New("")
+			if got := bad.Raw(); got != "" {
+				t.Errorf("expected Raw() to be empty string for invalid field, got %q", got)
+			}
+		})
+
+		t.Run("Renderable", func(t *testing.T) {
+			// Identifier with owner
+			f := field.NewWithTable("users", "id")
+			if got := f.String(); got != "✅ Field(\"users.id\")" {
+				t.Errorf("expected String() 'users.id', got %q", got)
+			}
+
+			// Computed expression with alias
+			f = field.New("SUM(qty)", "total", true)
+			if got := f.String(); got != "✅ Field(\"SUM(qty) AS total\")" {
+				t.Errorf("expected String() 'SUM(qty) AS total', got %q", got)
+			}
+
+			// Subquery with alias
+			f = field.New("(SELECT id FROM users) sub")
+			if got := f.String(); got != "✅ Field(\"(SELECT id FROM users) AS sub\")" {
+				t.Errorf("expected String() '(SELECT id FROM users) AS sub', got %q", got)
+			}
+
+			// Invalid field → String() must show diagnostic, never empty
+			bad := field.New("")
+			if got := bad.String(); got != "⛔ Field(\"\"): empty expression is not allowed" {
+				t.Errorf("expected %q, got %q", "⛔️ Field(\"\"): empty expression is not allowed", got)
+			}
+		})
+
+		t.Run("Stringable", func(t *testing.T) {
+			// Identifier
+			f := field.New("id")
+			if got := f.String(); got != "✅ Field(\"id\")" {
+				t.Errorf("expected String() 'id', got %q", got)
+			}
+
+			// With table owner
+			f = field.NewWithTable("users", "id")
+			if got := f.String(); got != "✅ Field(\"users.id\")" {
+				t.Errorf("expected String() 'users.id', got %q", got)
+			}
+
+			// Computed expression with alias
+			f = field.New("SUM(qty)", "total", true)
+			if got := f.String(); got != "✅ Field(\"SUM(qty) AS total\")" {
+				t.Errorf("expected String() 'SUM(qty) AS total', got %q", got)
+			}
+
+			// Subquery
+			f = field.New("(SELECT id FROM users) u")
+			if got := f.String(); got != "✅ Field(\"(SELECT id FROM users) AS u\")" {
+				t.Errorf("expected String() '(SELECT id FROM users) AS u', got %q", got)
+			}
+
+			// Invalid
+			bad := field.New("")
+			if got := bad.String(); got != "⛔ Field(\"\"): empty expression is not allowed" {
+				t.Errorf("expected contains 'empty expression is not allowed' for invalid field, got %q", got)
+			}
+		})
+	})
+
+	t.Run("EdgeCases", func(t *testing.T) {
+		t.Run("HasTrailingAliasWithoutAS", func(t *testing.T) {
+			// Single token: false
+			if field.HasTrailingAliasWithoutAS("id") {
+				t.Error("expected false for single token expr")
+			}
+
+			// Valid trailing alias: true
+			if !field.HasTrailingAliasWithoutAS("SUM(price) total") {
+				t.Error("expected true when trailing alias looks like identifier")
+			}
+
+			// Invalid trailing alias (symbolic): false
+			if field.HasTrailingAliasWithoutAS("col1 + col2 123") {
+				t.Error("expected false when trailing token is not valid identifier")
 			}
 		})
 	})

--- a/db/token/table/README.md
+++ b/db/token/table/README.md
@@ -1,7 +1,7 @@
 <h1 align="left">
   <img src="https://github.com/entiqon/entiqon/blob/main/assets/entiqon_datacon.png?raw=true" align="left" height="82" width="82" alt=""> Table
 </h1>
-<h6 align="left">Part of the <a href="https://github.com/entiqon/entiqon">Entiqon</a> / <a href="https://github.com/entiqon/entiqon/tree/main/db">Database</a> / <a href="https://github.com/entiqon/entiqon/tree/main/db/token">Token</a> toolkit.</h6>
+<h6 align="left">Part of the <a href="../../../README.md">Entiqon</a> / <a href="../../README.md">Database</a> / <a href="../README.md">Token</a> toolkit.</h6>
 
 ## 🌱 Overview
 


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- [x] Tests written and passing (nil → valid → edge cases).  
- [x] Tests follow `file → methods → cases` pattern with **PascalCase**.  
- [x] Docs updated:
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
