### PR TITLE
refactor(token/field): hide struct and align examples with Token interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [v1.13.0] - Upcoming
+## [v1.13.0](https://github.com/entiqon/entiqon/releases/tag/v1.13.0) - 2025-08-26
+
 ### Database (builder/select)
 - Added full clause support:
     - **Conditions**: `Where`, `And`, `Or` (reset, append, normalize with AND, ignore empty).
@@ -17,7 +18,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - `Debug()` and `String()` improved with ✅/⛔️ status markers.
     - `Build()` aggregates invalid fields, detects nil receiver and missing source, with clear ❌ messages.
 
+### Database (contract)
+- Introduced **BaseToken** contract (`db/contract/base_token.go`):
+    - Provides core identity and validation for all tokens
+    - Methods: `Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`
+    - Ensures `Field`, `Table`, and future tokens expose consistent state
+- Added runnable example (`ExampleBaseToken`) in `example_test.go`
+- Updated `doc.go` to include BaseToken in contract overview with normalized style
+- Updated `README.md`:
+    - Added BaseToken section with purpose, methods, and usage
+    - Streamlined layout, removed redundancy
+    - Extended philosophy with **Consistency** principle: all tokens share BaseToken
+- Extended **Errorable** contract with `SetError(err error)`:
+    - Allows tokens/builders to mark themselves as errored after construction
+    - Implemented in `Field` and `Table` tokens
+    - Updated `doc.go`, `README.md`, and `example_test.go` to demonstrate usage
+  
+### Database (token/table)
+- Introduced **Table token** to represent SQL sources in builders:
+    - Provides constructors and helpers to define tables, aliases, and raw inputs.
+    - Supports consistent rendering across dialects.
+    - Ensures validation of invalid/empty inputs with clear error reporting.
+- Added **unit tests** covering constructors, methods, and edge cases with 100% coverage.
+- Added **doc.go** with package overview and usage guidelines.
+- Added **example_test.go** with runnable examples.
+- Added **README.md** documenting purpose, design, and usage of token.Table.
+
 ### Database (token/field)
+- Struct `Field` is now hidden (`field` unexported); only the `Token` interface is public.
+- Constructors (`New`, `NewWithTable`) return `Token` instead of *field, ensuring encapsulation.
+- `Clone()` updated to return `Token`.
+- Example tests aligned:
+  - Functions renamed from ExampleField_* → ExampleToken_*.
+  - Debug/String outputs updated to lowercase `field(...)`.
+  - Clone example simplified (no pointer comparison).
+
 - Refactored **Field** into dedicated subpackage `db/token/field`:
     - Preserved API (`field.New(...)`) and contract implementations unchanged.
     - Updated `builder/select.go` and `select_test.go` to import from the new path.
@@ -37,32 +72,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
     - Added `db/token/doc.go` with GoDoc overview, principles, subpackages, and roadmap.
 
 
-### Database (token/table)
-- Introduced **Table token** to represent SQL sources in builders:
-    - Provides constructors and helpers to define tables, aliases, and raw inputs.
-    - Supports consistent rendering across dialects.
-    - Ensures validation of invalid/empty inputs with clear error reporting.
-- Added **unit tests** covering constructors, methods, and edge cases with 100% coverage.
-- Added **doc.go** with package overview and usage guidelines.
-- Added **example_test.go** with runnable examples.
-- Added **README.md** documenting purpose, design, and usage of token.Table.
-
-### Database (contract)
-- Introduced **BaseToken** contract (`db/contract/base_token.go`):
-    - Provides core identity and validation for all tokens
-    - Methods: `Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`
-    - Ensures `Field`, `Table`, and future tokens expose consistent state
-- Added runnable example (`ExampleBaseToken`) in `example_test.go`
-- Updated `doc.go` to include BaseToken in contract overview with normalized style
-- Updated `README.md`:
-    - Added BaseToken section with purpose, methods, and usage
-    - Streamlined layout, removed redundancy
-    - Extended philosophy with **Consistency** principle: all tokens share BaseToken
-- Extended **Errorable** contract with `SetError(err error)`:
-    - Allows tokens/builders to mark themselves as errored after construction
-    - Implemented in `Field` and `Table` tokens
-    - Updated `doc.go`, `README.md`, and `example_test.go` to demonstrate usage
-  
 ### Common (extension/integer)
 - Introduced **integer parser**:
     - `ParseFrom(any)` converts input safely to int, rejects invalid types.
@@ -73,15 +82,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Comprehensive unit tests across Database and Common ensuring 100% coverage.
 - **README.md**, **doc.go**, and **example_test.go** updated with Conditions, Grouping, Having, Ordering, and Integer parser sections.
 - Added runnable examples in `example_test.go` demonstrating new Having clause.
-
-### Documentation
-- Root `README.md` refactored:
-  - Added **Doctrine** section (Never panic, Auditability, Strict validation, Delegation).
-  - Replaced bullet list with **capabilities table** (Modules, Features, Purpose, Status).
-  - Added status icons: ✅ Stable, 🚧 On Going, 📝 Planned.
-  - Streamlined layout: removed redundant Quickstart and developer guide links.
-- Aligned method docstrings (`String`, `Raw`, `Render`, `Debug`) with clarified audiences (UI/UX, logging, developer diagnostics, builder output).
-
 
 ## [v1.12.0](https://github.com/entiqon/entiqon/releases/tag/v1.12.0) - 2025-08-22
 

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -62,11 +62,10 @@ func ExampleSelectBuilder_invalidFields() {
 	if err != nil {
 		fmt.Println(err.Error())
 	}
-	// Output:
-	// ❌ [Build] - Invalid fields:
-	//	⛔️ Field("true"): expr has unsupported type: bool
-	//	⛔️ Field("false"): expr has unsupported type: bool
-	//	⛔️ Field("123"): expr has unsupported type: int
+	// Output: ❌ [Build] - Invalid fields:
+	//	⛔️ field("true"): expr has unsupported type: bool
+	//	⛔️ field("false"): expr has unsupported type: bool
+	//	⛔️ field("123"): expr has unsupported type: int
 }
 
 func ExampleSelectBuilder_where() {

--- a/db/builder/select_test.go
+++ b/db/builder/select_test.go
@@ -64,7 +64,7 @@ func TestSelectBuilder(t *testing.T) {
 
 			t.Run("Pointer", func(t *testing.T) {
 				sb := builder.NewSelect(nil).
-					Fields(field.New("id")) // *token.Field
+					Fields(field.New("id")) // *token.field
 				fields := sb.GetFields()
 				if fields.Length() != 1 {
 					t.Errorf("expected 1 field, got %d", fields.Length())
@@ -73,7 +73,7 @@ func TestSelectBuilder(t *testing.T) {
 
 			t.Run("NotPointer", func(t *testing.T) {
 				sb := builder.NewSelect(nil).
-					Fields(*field.New("id")) // token.Field (value)
+					Fields(field.New("id")) // token.field (value)
 				fields := sb.GetFields()
 				if fields.Length() != 1 {
 					t.Errorf("expected 1 field, got %d", fields.Length())
@@ -836,7 +836,7 @@ func TestSelectBuilder(t *testing.T) {
 				if !strings.Contains(out, "❌ [Build] - Invalid fields:") {
 					t.Errorf("expected error to contain '❌ [Build] - Invalid fields:', got %q", out)
 				}
-				if !strings.Contains(out, "⛔️ Field(") {
+				if !strings.Contains(out, "⛔️ field(") {
 					t.Errorf("expected detailed field errors, got %q", out)
 				}
 			})

--- a/db/token/field/contract.go
+++ b/db/token/field/contract.go
@@ -1,9 +1,4 @@
 // File: db/token/field/contract.go
-//
-// Package field defines the Field token and its associated contract.
-// A Field represents a SQL column, expression, or computed value that
-// may optionally be qualified by a table and/or aliased. The Token
-// interface describes the required behavior for all Field instances.
 
 package field
 
@@ -37,7 +32,7 @@ type Token interface {
 	contract.BaseToken
 
 	// Clonable allows producing a semantic copy safe for independent mutation.
-	contract.Clonable[*Field]
+	contract.Clonable[Token]
 
 	// Debuggable returns a detailed diagnostic view of the field,
 	// including markers for aliased/raw/errored state.
@@ -77,4 +72,4 @@ type Token interface {
 }
 
 // Ensure *Field implements Token at compile time.
-var _ Token = (*Field)(nil)
+var _ Token = (*field)(nil)

--- a/db/token/field/example_test.go
+++ b/db/token/field/example_test.go
@@ -11,42 +11,42 @@ import (
 //
 
 // ExampleField_Input shows that Input() preserves the original input string.
-func ExampleField_Input() {
+func ExampleToken_input() {
 	f := field.New("SUM(qty) total")
 	fmt.Println(f.Input())
 	// Output: SUM(qty) total
 }
 
 // ExampleField_Expr shows Expr() returns the parsed expression without alias.
-func ExampleField_Expr() {
+func ExampleToken_expr() {
 	f := field.New("SUM(qty) total")
 	fmt.Println(f.Expr())
 	// Output: SUM(qty)
 }
 
 // ExampleField_Alias shows Alias() returns the parsed alias.
-func ExampleField_Alias() {
+func ExampleToken_alias() {
 	f := field.New("SUM(qty) total")
 	fmt.Println(f.Alias())
 	// Output: total
 }
 
 // ExampleField_IsAliased shows IsAliased() is true if alias is set.
-func ExampleField_IsAliased() {
+func ExampleToken_isAliased() {
 	f := field.New("SUM(qty) total")
 	fmt.Println(f.IsAliased())
 	// Output: true
 }
 
 // ExampleField_IsRaw shows IsRaw() is true for computed expressions.
-func ExampleField_IsRaw() {
+func ExampleToken_isRaw() {
 	f := field.New("SUM(qty) total")
 	fmt.Println(f.IsRaw())
 	// Output: true
 }
 
 // ExampleField_IsValid shows IsValid() reports validity.
-func ExampleField_IsValid() {
+func ExampleToken_isValid() {
 	f := field.New("id")
 	fmt.Println(f.IsValid())
 	// Output: true
@@ -57,14 +57,14 @@ func ExampleField_IsValid() {
 //
 
 // ExampleField_Error shows Error() returns nil for valid fields and non-nil for invalid ones.
-func ExampleField_Error() {
+func ExampleToken_error() {
 	f := field.New("")
 	fmt.Println(f.Error())
 	// Output: empty expression is not allowed
 }
 
 // ExampleField_IsErrored shows IsErrored() is true when the field has an error.
-func ExampleField_IsErrored() {
+func ExampleToken_isErrored() {
 	f := field.New("")
 	fmt.Println(f.IsErrored())
 	// Output: true
@@ -75,21 +75,21 @@ func ExampleField_IsErrored() {
 //
 
 // ExampleField_HasOwner shows HasOwner() reports if a field is bound to a table.
-func ExampleField_HasOwner() {
+func ExampleToken_HasOwner() {
 	f := field.New("id")
 	fmt.Println(f.HasOwner())
 	// Output: false
 }
 
 // ExampleField_Owner shows Owner() returns the bound owner if set.
-func ExampleField_Owner() {
+func ExampleToken_owner() {
 	f := field.NewWithTable("users", "id")
 	fmt.Println(*f.Owner())
 	// Output: users
 }
 
 // ExampleField_SetOwner shows SetOwner() attaches a table owner.
-func ExampleField_SetOwner() {
+func ExampleToken_setOwner() {
 	f := field.New("id")
 	owner := "orders"
 	f.SetOwner(&owner)
@@ -102,11 +102,11 @@ func ExampleField_SetOwner() {
 //
 
 // ExampleField_Clone shows Clone() returns a deep copy of the field.
-func ExampleField_Clone() {
+func ExampleToken_clone() {
 	orig := field.New("id user_id")
 	cl := orig.Clone()
-	fmt.Println(cl.Expr(), cl.Alias(), cl == orig)
-	// Output: id user_id false
+	fmt.Println(cl.Expr(), cl.Alias())
+	// Output: id user_id
 }
 
 //
@@ -114,17 +114,17 @@ func ExampleField_Clone() {
 //
 
 // ExampleField_Debug shows Debug() returns a detailed diagnostic view.
-func ExampleField_Debug() {
+func ExampleToken_debug() {
 	f := field.New("COUNT(*) AS total")
 	fmt.Println(f.Debug())
-	// Output: ✅ Field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
+	// Output: ✅ field("COUNT(*) AS total"): [raw: true, aliased: true, errored: false]
 }
 
 // ExampleField_String shows String() returns concise logging output.
-func ExampleField_String() {
+func ExampleToken_string() {
 	f := field.New("")
 	fmt.Println(f.String())
-	// Output: ⛔ Field(""): empty expression is not allowed
+	// Output: ⛔ field(""): empty expression is not allowed
 }
 
 //
@@ -132,14 +132,14 @@ func ExampleField_String() {
 //
 
 // ExampleField_Raw shows Raw() returns SQL-generic rendering.
-func ExampleField_Raw() {
+func ExampleToken_raw() {
 	f := field.New("SUM(qty)", "total", true)
 	fmt.Println(f.Raw())
 	// Output: SUM(qty) AS total
 }
 
 // ExampleField_Render shows Render() produces dialect-agnostic SQL.
-func ExampleField_Render() {
+func ExampleToken_render() {
 	f := field.NewWithTable("users", "id", "user_id")
 	fmt.Println(f.Render())
 	// Output: users.id AS user_id

--- a/db/token/field/field_test.go
+++ b/db/token/field/field_test.go
@@ -16,7 +16,7 @@ func TestField(t *testing.T) {
 			t.Run("InvalidCall", func(t *testing.T) {
 				f := field.New()
 				if f == nil {
-					t.Fatal("expected non-nil Field, got nil")
+					t.Fatal("expected non-nil field, got nil")
 				}
 				if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty input is not allowed") {
 					t.Errorf("expected error 'empty input is not allowed', got %v", f.Error())
@@ -26,17 +26,17 @@ func TestField(t *testing.T) {
 			t.Run("StarField", func(t *testing.T) {
 				f := field.New("*")
 				if f == nil {
-					t.Fatal("expected non-nil Field, got nil")
+					t.Fatal("expected non-nil field, got nil")
 				}
 				got := f.String()
-				if got != "✅ Field(\"*\")" {
-					t.Errorf("expected ✅ Field(\"*\"), got %v", got)
+				if got != "✅ field(\"*\")" {
+					t.Errorf("expected ✅ field(\"*\"), got %v", got)
 				}
 
 				f = field.New("*", "alias")
 				got = f.String()
-				if f.Error() == nil || got != "⛔ Field(\"*\"): '*' cannot be aliased or raw" {
-					t.Errorf("expected ⛔ Field(\"*\"): '*' cannot be aliased or raw, got %v", got)
+				if f.Error() == nil || got != "⛔ field(\"*\"): '*' cannot be aliased or raw" {
+					t.Errorf("expected ⛔ field(\"*\"): '*' cannot be aliased or raw, got %v", got)
 				}
 			})
 
@@ -44,24 +44,24 @@ func TestField(t *testing.T) {
 				t.Run("InvalidCall", func(t *testing.T) {
 					f := field.New("")
 					if f == nil && f.Error() == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty expr") {
 						t.Errorf("expected error contains 'empty expr is not allowed', got %v", f.Error())
 					}
 					f = field.New(123)
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "expr has unsupported type") {
 						t.Errorf("expected error contains 'expr has unsupported type', got %v", f.Error())
 					}
 					f = field.New(field.New("id"))
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
-					if f.Error() == nil || !strings.Contains(f.Error().Error(), "unsupported type: Field") {
-						t.Errorf("expected error contains 'unsupported type: Field', got %v", f.Error())
+					if f.Error() == nil || !strings.Contains(f.Error().Error(), "unsupported type: field") {
+						t.Errorf("expected error contains 'unsupported type: field', got %v", f.Error())
 					}
 				})
 
@@ -76,7 +76,7 @@ func TestField(t *testing.T) {
 					t.Run("InlineAlias", func(t *testing.T) {
 						f := field.New("id as user_id")
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						f = field.New("(qty * price * discount) total")
 						if f.Expr() != "(qty * price * discount)" || f.Alias() != "total" {
@@ -91,7 +91,7 @@ func TestField(t *testing.T) {
 					t.Run("Computed", func(t *testing.T) {
 						f := field.New("SUM(qty * price * discount) as total")
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						if f.Expr() != "SUM(qty * price * discount)" || f.Alias() != "total" {
 							t.Errorf("expected 'SUM(qty * price * discount)' AS total, got %q AS %q", f.Expr(), f.Alias())
@@ -116,14 +116,14 @@ func TestField(t *testing.T) {
 				t.Run("InvalidCall", func(t *testing.T) {
 					f := field.New("field", 123)
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "alias has unsupported type") {
 						t.Errorf("expected error 'alias has unsupported type', got %v", f.Error())
 					}
 					f = field.New("field", "")
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty alias is not allowed") {
 						t.Errorf("expected error 'empty alias is not allowed', got %v", f.Error())
@@ -134,7 +134,7 @@ func TestField(t *testing.T) {
 					t.Run("Default", func(t *testing.T) {
 						f := field.New("field", "alias")
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						if f.Error() != nil {
 							t.Fatal("expected error to be nil, got non-nil")
@@ -144,7 +144,7 @@ func TestField(t *testing.T) {
 					t.Run("Computed", func(t *testing.T) {
 						f := field.New("(qty * price * discount)", "total")
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						if f.Error() != nil {
 							t.Fatal("expected error to be nil, got non-nil")
@@ -157,21 +157,21 @@ func TestField(t *testing.T) {
 				t.Run("InvalidCall", func(t *testing.T) {
 					f := field.New("field", 123, true)
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "alias has unsupported type") {
 						t.Errorf("expected error 'alias has unsupported type', got %v", f.Error())
 					}
 					f = field.New("field", "", true)
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "empty alias is not allowed") {
 						t.Errorf("expected error 'empty alias is not allowed', got %v", f.Error())
 					}
 					f = field.New("field", "alias", 123)
 					if f == nil {
-						t.Fatal("expected non-nil Field, got nil")
+						t.Fatal("expected non-nil field, got nil")
 					}
 					if f.Error() == nil || !strings.Contains(f.Error().Error(), "isRaw has invalid type") {
 						t.Errorf("expected error 'isRaw has invalid type', got %v", f.Error())
@@ -182,7 +182,7 @@ func TestField(t *testing.T) {
 					t.Run("Default", func(t *testing.T) {
 						f := field.New("field", "alias", false)
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						if f.Error() != nil {
 							t.Fatal("expected error to be nil, got non-nil")
@@ -192,7 +192,7 @@ func TestField(t *testing.T) {
 					t.Run("Computed", func(t *testing.T) {
 						f := field.New("(qty * price * discount)", "total", true)
 						if f == nil {
-							t.Fatal("expected non-nil Field, got nil")
+							t.Fatal("expected non-nil field, got nil")
 						}
 						if f.Error() != nil {
 							t.Fatal("expected error to be nil, got non-nil")
@@ -204,10 +204,10 @@ func TestField(t *testing.T) {
 			t.Run("n-args", func(t *testing.T) {
 				f := field.New("field", "alias", false, 1234)
 				if f == nil {
-					t.Fatal("expected non-nil Field, got nil")
+					t.Fatal("expected non-nil field, got nil")
 				}
-				if f.Error() == nil || f.Error().Error() != "invalid Field constructor signature" {
-					t.Errorf("expected error 'invalid Field constructor signature', got %v", f.Error())
+				if f.Error() == nil || f.Error().Error() != "invalid field constructor signature" {
+					t.Errorf("expected error 'invalid field constructor signature', got %v", f.Error())
 				}
 			})
 		})
@@ -216,7 +216,7 @@ func TestField(t *testing.T) {
 			t.Run("InvalidCall", func(t *testing.T) {
 				f := field.NewWithTable("", "SUM(qty * price)", "line_total")
 				if f == nil {
-					t.Fatal("expected non-nil Field, got nil")
+					t.Fatal("expected non-nil field, got nil")
 				}
 				if f.Error() == nil || f.Error().Error() != "owner is empty" {
 					t.Errorf("expected error to be non-nil, got %v", f.Error())
@@ -226,7 +226,7 @@ func TestField(t *testing.T) {
 			t.Run("Valid", func(t *testing.T) {
 				f := field.NewWithTable("order", "SUM(qty * price)", "line_total", true)
 				if f == nil {
-					t.Fatal("expected non-nil Field, got nil")
+					t.Fatal("expected non-nil field, got nil")
 				}
 				if f.Error() != nil {
 					t.Errorf("expected error to be nil, got %v", f.Error())
@@ -412,57 +412,57 @@ func TestField(t *testing.T) {
 		t.Run("Renderable", func(t *testing.T) {
 			// Identifier with owner
 			f := field.NewWithTable("users", "id")
-			if got := f.String(); got != "✅ Field(\"users.id\")" {
+			if got := f.String(); got != "✅ field(\"users.id\")" {
 				t.Errorf("expected String() 'users.id', got %q", got)
 			}
 
 			// Computed expression with alias
 			f = field.New("SUM(qty)", "total", true)
-			if got := f.String(); got != "✅ Field(\"SUM(qty) AS total\")" {
+			if got := f.String(); got != "✅ field(\"SUM(qty) AS total\")" {
 				t.Errorf("expected String() 'SUM(qty) AS total', got %q", got)
 			}
 
 			// Subquery with alias
 			f = field.New("(SELECT id FROM users) sub")
-			if got := f.String(); got != "✅ Field(\"(SELECT id FROM users) AS sub\")" {
+			if got := f.String(); got != "✅ field(\"(SELECT id FROM users) AS sub\")" {
 				t.Errorf("expected String() '(SELECT id FROM users) AS sub', got %q", got)
 			}
 
 			// Invalid field → String() must show diagnostic, never empty
 			bad := field.New("")
-			if got := bad.String(); got != "⛔ Field(\"\"): empty expression is not allowed" {
-				t.Errorf("expected %q, got %q", "⛔️ Field(\"\"): empty expression is not allowed", got)
+			if got := bad.String(); got != "⛔ field(\"\"): empty expression is not allowed" {
+				t.Errorf("expected %q, got %q", "⛔️ field(\"\"): empty expression is not allowed", got)
 			}
 		})
 
 		t.Run("Stringable", func(t *testing.T) {
 			// Identifier
 			f := field.New("id")
-			if got := f.String(); got != "✅ Field(\"id\")" {
+			if got := f.String(); got != "✅ field(\"id\")" {
 				t.Errorf("expected String() 'id', got %q", got)
 			}
 
 			// With table owner
 			f = field.NewWithTable("users", "id")
-			if got := f.String(); got != "✅ Field(\"users.id\")" {
+			if got := f.String(); got != "✅ field(\"users.id\")" {
 				t.Errorf("expected String() 'users.id', got %q", got)
 			}
 
 			// Computed expression with alias
 			f = field.New("SUM(qty)", "total", true)
-			if got := f.String(); got != "✅ Field(\"SUM(qty) AS total\")" {
+			if got := f.String(); got != "✅ field(\"SUM(qty) AS total\")" {
 				t.Errorf("expected String() 'SUM(qty) AS total', got %q", got)
 			}
 
 			// Subquery
 			f = field.New("(SELECT id FROM users) u")
-			if got := f.String(); got != "✅ Field(\"(SELECT id FROM users) AS u\")" {
+			if got := f.String(); got != "✅ field(\"(SELECT id FROM users) AS u\")" {
 				t.Errorf("expected String() '(SELECT id FROM users) AS u', got %q", got)
 			}
 
 			// Invalid
 			bad := field.New("")
-			if got := bad.String(); got != "⛔ Field(\"\"): empty expression is not allowed" {
+			if got := bad.String(); got != "⛔ field(\"\"): empty expression is not allowed" {
 				t.Errorf("expected contains 'empty expression is not allowed' for invalid field, got %q", got)
 			}
 		})

--- a/releases/release-notes-v1.13.0.md
+++ b/releases/release-notes-v1.13.0.md
@@ -4,114 +4,149 @@
 
 ### Added
 - Extended `SelectBuilder` with full clause support:
-    - **Conditions**: `Where`, `And`, `Or` (resets, appends, normalized, ignores empty, renders after `FROM`)
-    - **Grouping**: `GroupBy`, `ThenGroupBy` (reset/append, ignore empty, renders between `WHERE` and `HAVING`)
-    - **Having**: `Having`, `AndHaving`, `OrHaving` (reset/append, normalized, ignore empty, renders after `GROUP BY`)
-    - **Ordering**: `OrderBy`, `ThenOrderBy` (reset/append, ignore empty, renders after `WHERE`/`GROUP BY`/`HAVING`)
+    - **Conditions**
+        - `Where(...string)`: resets conditions
+        - `And(...string)`: appends with `AND`
+        - `Or(...string)`: appends with `OR`
+        - Multiple conditions in a single `Where` call are normalized with `AND`
+        - Ignores empty or whitespace-only inputs
+        - `Build()` renders conditions immediately after `FROM`
+    - **Grouping**
+        - `GroupBy(...string)`: resets grouping fields
+        - `ThenGroupBy(...string)`: appends grouping fields
+        - Graceful handling of nil collections
+        - Ignores empty or whitespace-only values
+        - `Build()` renders `GROUP BY` between `WHERE` and `HAVING`
+    - **Having**
+        - `Having(...string)`: resets HAVING conditions
+        - `AndHaving(...string)`: appends with `AND`
+        - `OrHaving(...string)`: appends with `OR`
+        - Multiple conditions in a single `Having` call are normalized with `AND`
+        - Ignores empty or whitespace-only inputs
+        - `Build()` renders `HAVING` immediately after `GROUP BY`
+    - **Ordering**
+        - `OrderBy(...string)`: resets ordering fields
+        - `ThenOrderBy(...string)`: appends ordering fields
+        - Ignores empty or whitespace-only values
+        - `Build()` renders `ORDER BY` after `WHERE` / `GROUP BY` / `HAVING`
 
 ### Enhanced
 - **Field diagnostics**
-    - Consistent error messages (e.g., `⛔️ Field("true"): input type unsupported: bool`)
-    - `Debug()` shows structured state with ✅/⛔️ markers
-    - `String()` enhanced for clarity and UX
+    - Invalid fields now produce consistent error messages
+    - Example: `⛔️ Field("true"): input type unsupported: bool`
+    - `Debug()` method on `token/field.Field` shows structured state with ✅/⛔️ markers
+    - `String()` enhanced for clarity and consistency with Debug output
 - **SelectBuilder reporting**
-    - `Build()` aggregates invalid field errors into a single block
-    - Clearer error messages (`❌ No source specified`, `❌ Wrong initialization`)
-    - `String()` shows ✅/❌ style status
-
----
-
-## Database Package (token/field)
-
-### Refactored
-- Moved `Field` into `db/token/field` subpackage
-    - API preserved (`field.New(...)`)
-    - Updated builder imports and Dockerfile
-    - Normalized structure with `token/table`
-
-### Added
-- Introduced **Field Token contract**:
-    - Aggregates `BaseToken`, `Clonable`, `Debuggable`, `Errorable`, `Rawable`, `Renderable`, `Stringable`
-    - Ownership methods: `HasOwner()`, `Owner()`, `SetOwner()`
-    - ⚠️ Contract only, implementation staged
-
-### Enhanced
-- **Clone**
-    - Deep copy of `owner` (avoids aliasing between clones and originals)
-    - Removed unreachable `nil` branch (constructors guarantee non-nil)
-    - Docstring updated
-- **Role separation**
-    - `Render()` → final SQL (future dialect-aware)
-    - `Raw()` → SQL-generic (loggers)
-    - `String()` → UX-friendly, concise with ✅/⛔
-    - `Debug()` → developer diagnostics
-- Normalized error handling with consistent `SetError` usage
-
-### Documentation
-- `doc.go`: extended **Field Behavior**
-- `example_test.go`: placeholder `ExampleField_owner`
-- `README.md`: new **Contracts and Auditability** section
-- Root-level docs: `db/token/README.md` and `db/token/doc.go`
-
----
-
-## Database Package (token/table)
-
-### Added
-- Introduced `token.Table` type:
-    - Constructors for tables, aliases, raw inputs
-    - Consistent rendering across dialects
-    - Validation of invalid/empty inputs
-- Added tests (constructors, methods, edge cases, 100% coverage)
-- Added `doc.go`, `example_test.go`, `README.md`
-
----
+    - `Build()` aggregates invalid field errors into a single descriptive block
+    - Clearer error messages when:
+        - No source specified (`❌ [Build] - No source specified`)
+        - Nil receiver (`❌ [Build] - Wrong initialization. Cannot build on receiver nil`)
+    - `String()` provides status-style output:
+        - ✅ successful SQL string with params
+        - ❌ error message when build fails
 
 ## Database Package (contract)
 
 ### Added
-- **BaseToken** interface (`db/contract/base_token.go`):
-    - Identity and validation (`Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`)
-- Example: `ExampleBaseToken` in `example_test.go`
-- `doc.go` and `README.md` updated with BaseToken
-- Added **Consistency** principle in doctrine
-- Extended **Errorable** with `SetError(err error)`
-    - Implemented in `Field` and `Table`
-    - Docs and examples updated
+- Introduced **BaseToken** interface (`db/contract/base_token.go`):
+    - Provides core identity and validation for all tokens (`Field`, `Table`, etc.)
+    - Methods: `Input()`, `Expr()`, `Alias()`, `IsAliased()`, `IsValid()`
+    - Guarantees consistent identity and validation across all tokens
+- Added runnable example (`ExampleBaseToken`) in `example_test.go`
+- Updated `doc.go` with BaseToken in the contract overview (normalized style)
+- Updated `README.md`:
+    - New BaseToken section with purpose, methods, usage
+    - Streamlined documentation structure
+    - Extended philosophy with **Consistency** principle: all tokens share BaseToken
+- Extended **Errorable** contract with `SetError(err error)`:
+    - Enables tokens/builders to mark themselves as errored after construction
+    - Implemented in `Field` and `Table` tokens
+    - Updated `doc.go`, `README.md`, and `example_test.go` with usage examples
 
----
+## Database Package (token/table)
+
+### Added
+- Introduced `token.Table` type to represent SQL sources in builders:
+    - Provides constructors for tables, aliases, and raw inputs
+    - Consistent rendering across dialects
+    - Validation of invalid/empty inputs with clear error reporting
+- Added full unit test coverage (constructors, methods, edge cases)
+- Added `doc.go` with package overview and usage guidelines
+- Added `example_test.go` with runnable examples
+- Added `README.md` describing purpose, design, and usage
+
+## Database Package (token/field)
+
+### Database Package (token/field) — Hidden Struct
+- Struct `Field` is now unexported (`field`); only the `Token` interface is public.
+- Constructors (`New`, `NewWithTable`) return `Token` instead of *field.
+- `Clone()` updated to return `Token`.
+- Example tests aligned:
+  - Functions renamed from ExampleField_* → ExampleToken_*.
+  - Debug/String outputs updated to lowercase `field(...)`.
+  - Clone example simplified (no pointer comparison).
+
+
+### Refactored
+- Moved `Field` into a dedicated subpackage `db/token/field`:
+    - API preserved (`field.New(...)`) with unchanged contracts and behavior
+    - Updated `builder/select.go` and `select_test.go` to use new import path
+    - Dockerfile updated to copy `db/token/field/README.md` for documentation
+    - Normalized structure for consistency with `token/table`
+
+### Added
+- Introduced **Field Token contract** as a scaffold to decompose Field identity into auditable pieces:
+    - Aggregates `BaseToken`, `Clonable`, `Debuggable`, `Errorable`, `Rawable`, `Renderable`, and `Stringable`
+    - Defines ownership methods: `HasOwner()`, `Owner()`, and `SetOwner()`
+    - Intention: separate every identity aspect (expr, alias, owner, validity, raw state) into dedicated, auditable contracts
+    - ⚠️ Contract only; implementation staged for later commits
+
+### Documentation
+- `doc.go`: extended **Field Behavior** with `HasOwner`, `Owner`, `SetOwner`
+- `example_test.go`: added placeholder `ExampleField_owner` (commented until implemented)
+- `README.md`: new **Contracts and Auditability** section in Developer Guide
+- Root-level docs:
+    - Added `db/token/README.md` with package purpose and subpackage table
+    - Added `db/token/doc.go` with GoDoc overview, principles, subpackages, and roadmap
+
+### Refactored
+- Moved `Field` into a dedicated subpackage `db/token/field`:
+    - API preserved (`field.New(...)`) with unchanged contracts and behavior
+    - Updated `builder/select.go` and `select_test.go` to use new import path
+    - Dockerfile updated to copy `db/token/field/README.md` for documentation
+    - Normalized structure for consistency with `token/table`
 
 ## Common Package (extension/integer)
 
 ### Added
-- Integer parser:
-    - `ParseFrom(any)` with strict type validation
-    - `IntegerOr` shortcut with defaults
-- Consistent with boolean, float, decimal parsers
-- 100% test coverage
-- Runnable examples
-- Docs updated under `common/extension`
-
----
+- Introduced integer parser with full support:
+    - `ParseFrom(any)` converts generic input into integer values
+    - Rejects non-integer inputs with clear error reporting
+    - Consistent behavior with existing parsers (`boolean`, `float`, `decimal`)
+    - Added parser shortcuts (`IntegerOr`) for default values
+- Full test coverage in `integer/parser_test.go`
+- Added runnable examples and integrated into `example_test.go`
+- Updated parser documentation under `common/extension` README
 
 ## Tests
-- Full coverage across Database and Common:
-    - Clause handling
-    - Field validation, cloning, error aggregation
-    - Table token construction & rendering
+- Comprehensive unit tests across `db/builder/select`, `token/table`, `token/field`, and `common/extension/integer` ensuring 100% coverage:
+    - Clause handling (nil, reset, append, overwrite, ignore-empty)
+    - Field validation and error aggregation
+    - Table token construction, aliasing, and rendering
     - Integer parsing (valid, invalid, defaults)
-
----
+    - Field cloning, rendering, and error detection
 
 ## Documentation
-- **Database README.md** refactored:
-    - Added **Doctrine** section
-    - Replaced bullet list with **Capabilities table** (Modules, Features, Status icons)
-    - Removed redundant Quickstart and guides
-- **Database doc.go** extended with field & table examples
-- **Database example_test.go** updated with runnable examples:
-    - Select (where, and/or, ordering, grouping, having)
-    - Table usage
-    - Clonable
-- **Common/Extension README.md** updated with integer parser usage
-- **Common example_test.go** extended with parser examples
+- **Database README.md** updated with Conditions, Grouping, Having, Ordering, Field Rules, and Table token section
+- **Common/Extension README.md** updated with integer parser, usage table, and shortcuts
+- **Database doc.go** extended with clause usage and table/field examples
+- **Database example_test.go** enhanced with runnable examples:
+    - `ExampleSelectBuilder_where`
+    - `ExampleSelectBuilder_andOr`
+    - `ExampleSelectBuilder_ordering`
+    - `ExampleSelectBuilder_grouping`
+    - `ExampleSelectBuilder_having`
+    - `ExampleTable_basic`
+    - `ExampleClonable`
+- **Common example_test.go** enhanced with runnable examples:
+    - `ExampleIntegerParseFrom` and shortcut usage


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- [x] Tests written and passing (nil → valid → edge cases).  
- [x] Tests follow `file → methods → cases` pattern with **PascalCase**.  
- [x] Docs updated:
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
