### PR TITLE
refactor(helpers): streamline ResolveExpression with classifier-driven branching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
         - Added `example_test.go` demonstrating usage including edge cases.
 
 ### Token (helpers)
+- Refactored **ResolveExpression** in `helpers/identifier.go`:
+  - Branches directly on `ResolveExpressionType`, eliminating redundant checks.
+  - Unified alias handling for all expression types (`Identifier`, `Subquery`, `Computed`, `Aggregate`, `Function`, `Literal`).
+  - Removed unreachable `default` branch, ensuring full coverage.
+  - Simplified responsibility split: classification validates kind/shape, resolution only extracts alias.
+
 - Introduced **helpers** package for reusable validation utilities.
     - Identifier validation:
         - `IsValidIdentifier` / `ValidateIdentifier` with strict rules.

--- a/db/token/helpers/example_test.go
+++ b/db/token/helpers/example_test.go
@@ -140,3 +140,57 @@ func ExampleResolveExpressionType() {
 	// Identifier
 	// Invalid
 }
+
+// ExampleResolveExpression demonstrates parsing and classifying expressions
+// with optional aliases.
+func ExampleResolveExpression() {
+	// Identifier without alias
+	kind, expr, alias, err := helpers.ResolveExpression("id", true)
+	fmt.Println(kind, expr, alias, err)
+
+	// Identifier with alias using AS
+	kind, expr, alias, err = helpers.ResolveExpression("id AS user_id", true)
+	fmt.Println(kind, expr, alias, err)
+
+	// Identifier with alias using AS not allowAlias
+	kind, expr, alias, err = helpers.ResolveExpression("id AS user_id", false)
+	fmt.Println(kind, expr, alias, err)
+
+	// Subquery with alias
+	kind, expr, alias, err = helpers.ResolveExpression("(SELECT * FROM users) u", true)
+	fmt.Println(kind, expr, alias, err)
+
+	// Computed expression with alias
+	kind, expr, alias, err = helpers.ResolveExpression("(price * qty) total", true)
+	fmt.Println(kind, expr, alias, err)
+
+	// Aggregate with alias
+	kind, expr, alias, err = helpers.ResolveExpression("COUNT(*) AS total", true)
+	fmt.Println(kind, expr, alias, err)
+
+	// Invalid: alias not allowed
+	kind, expr, alias, err = helpers.ResolveExpression("id user_id", false)
+	fmt.Println(kind, expr, alias, err != nil)
+
+	// Identifier without alias
+	kind, expr, alias, err = helpers.ResolveExpression("(SELECT COUNT(id) FROM users) 123456", true)
+	fmt.Println(kind, expr, alias, err)
+
+	kind, expr, alias, err = helpers.ResolveExpression("(SELECT COUNT(id) FROM users) 123456", false)
+	fmt.Println(kind, expr, alias, err)
+
+	kind, expr, alias, err = helpers.ResolveExpression("(SELECT COUNT(id) FROM users) AS 123456", false)
+	fmt.Println(kind, expr, alias, err)
+
+	// Output:
+	// Identifier id  <nil>
+	// Identifier id user_id <nil>
+	// Invalid   alias not allowed: id AS user_id
+	// Subquery (SELECT * FROM users) u <nil>
+	// Computed (price * qty) total <nil>
+	// Aggregate COUNT(*) total <nil>
+	// Invalid   true
+	// Invalid (SELECT COUNT(id) FROM users)  invalid alias: 123456
+	// Invalid (SELECT COUNT(id) FROM users)  alias not allowed: (SELECT COUNT(id) FROM users) 123456
+	// Invalid (SELECT COUNT(id) FROM users)  alias not allowed: (SELECT COUNT(id) FROM users) AS 123456
+}

--- a/releases/release-notes-v1.14.0.md
+++ b/releases/release-notes-v1.14.0.md
@@ -28,6 +28,13 @@ We have introduced a new **identifier.Type** enum to classify SQL expressions in
 ---
 
 ### Token (helpers)
+#### Refactor
+- **ResolveExpression** in `helpers/identifier.go` has been streamlined:
+  - Branches directly on `ResolveExpressionType`, eliminating redundant checks.
+  - Unified alias handling for all expression types (`Identifier`, `Subquery`, `Computed`, `Aggregate`, `Function`, `Literal`).
+  - Removed unreachable `default` branch, ensuring full coverage.
+  - Simplified responsibility split: classification validates kind/shape, resolution only extracts alias.
+
 The expression classifier has been normalized and renamed.
 
 #### Changes


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- [x] Tests written and passing (nil → valid → edge cases).  
- [x] Tests follow `file → methods → cases` pattern with **PascalCase**.  
- [x] Docs updated:
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
