### PR TITLE
refactor(contract): remove ResolveType from Validable, move to helpers

### DIFF
--- a/db/contract/validable.go
+++ b/db/contract/validable.go
@@ -4,7 +4,6 @@ package contract
 
 import (
 	"errors"
-	"fmt"
 )
 
 var (
@@ -49,25 +48,4 @@ type Validable interface {
 	// It must return true only when the token has no error
 	// and its essential invariants are satisfied.
 	IsValid() bool
-}
-
-// ValidateType ensures input type is allowed for token constructors.
-//
-// Rules:
-//   - string → OK
-//   - any Validable (Field, Table, etc.) → ErrUnsupportedType
-//   - everything else → invalid format with type name
-func ValidateType(v any) error {
-	switch v.(type) {
-	case string:
-		return nil
-
-	case Validable:
-		// Already a token (Field, Table, etc.)
-		return ErrUnsupportedType
-
-	default:
-		// Everything else → invalid format
-		return fmt.Errorf("invalid format (type %T)", v)
-	}
 }


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- Tests follow `file → methods → cases` pattern with **PascalCase**.
  - [ ] `doc.go`
  - [ ] `README.md`
  - [ ] `example_test.go`
  - [ ] `CHANGELOG.md`
  - [ ] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
