### PR TITLE
feat(builder): add join support with where, order, limit and offset in SelectBuilder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - **Condition**: introduced `Token` interface and implementation with constructors (`New`, `NewAnd`, `NewOr`) and
   operator/value validation.
 - **Field/Table**: constructors delegate to `resolver.ValidateType`; stricter validation & clearer errors.
+- **Join**: added support for CROSS and NATURAL joins, with consistent token modeling (anchor `left`, hosted `right`).
+
+### Builder
+
+- **SelectBuilder** extended:
+    - Full join support: `InnerJoin`, `LeftJoin`, `RightJoin`, `FullJoin`, `CrossJoin`, `NaturalJoin`.
+    - Added chaining for `Where`, `OrderBy`, `Limit`, `Offset` in examples and documentation.
+    - Improved `Build()` aggregation to include joins and ordering consistently.
 
 ### Helpers
 
@@ -41,9 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Docs & Tests
 
-- Updated all `doc.go` and `README.md` files for new/changed tokens.
-- Expanded `example_test.go` with subqueries, identifiers, aliases, wildcards, generated aliases, and classification.
-- Achieved 100% coverage for new contracts and helpers.
+- Updated all `doc.go` and `README.md` files for new/changed tokens and builder features.
+- Expanded `example_test.go` with join examples, subqueries, identifiers, aliases, wildcards, and classification.
+- Achieved 100% coverage for new contracts, helpers, and builder flows.
 
 ## [v1.13.0](https://github.com/entiqon/entiqon/releases/tag/v1.13.0) - 2025-08-26
 

--- a/db/builder/example_test.go
+++ b/db/builder/example_test.go
@@ -160,3 +160,115 @@ func ExampleSelectBuilder_limit() {
 	// Output:
 	// SELECT * FROM table WHERE field = 1 LIMIT 1
 }
+
+// --- JOIN Examples ---
+
+func ExampleSelectBuilder_innerJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("u.id, o.total").
+		Source("users u").
+		InnerJoin("users", "orders o", "u.id = o.user_id").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT u.id, o.total FROM users AS u INNER JOIN orders AS o ON u.id = o.user_id
+}
+
+func ExampleSelectBuilder_leftJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("u.id, o.total").
+		Source("users u").
+		LeftJoin("users", "orders o", "u.id = o.user_id").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT u.id, o.total FROM users AS u LEFT JOIN orders AS o ON u.id = o.user_id
+}
+
+func ExampleSelectBuilder_rightJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("u.id, o.total").
+		Source("users u").
+		RightJoin("users", "orders o", "u.id = o.user_id").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT u.id, o.total FROM users AS u RIGHT JOIN orders AS o ON u.id = o.user_id
+}
+
+func ExampleSelectBuilder_fullJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("u.id, o.total").
+		Source("users u").
+		FullJoin("users", "orders o", "u.id = o.user_id").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT u.id, o.total FROM users AS u FULL JOIN orders AS o ON u.id = o.user_id
+}
+
+func ExampleSelectBuilder_crossJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("u.id, r.role").
+		Source("users u").
+		CrossJoin("users u", "roles r"). // condition ignored
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT u.id, r.role FROM users AS u CROSS JOIN roles AS r
+}
+
+func ExampleSelectBuilder_naturalJoin() {
+	sql, _ := builder.NewSelect(nil).
+		Fields("e.id, d.name").
+		Source("employees e").
+		NaturalJoin("departments d").
+		Build()
+
+	fmt.Println(sql)
+	// Output: SELECT e.id, d.name FROM employees AS e NATURAL JOIN departments AS d
+}
+
+// ExampleSelectBuilder_getFields demonstrates how to access fields
+// already added to the builder using GetFields().
+func ExampleSelectBuilder_getFields() {
+	sb := builder.NewSelect(nil).
+		Fields("id").
+		AddFields("name").
+		Source("users")
+
+	// Get the fields as a collection
+	fields := sb.GetFields()
+	for _, f := range fields.Items() {
+		fmt.Print(f.Render(), " ")
+	}
+
+	// Output: id name
+}
+
+// ExampleSelectBuilder_debug demonstrates the developer-facing Debug()
+// output, which includes internal state such as counts of clauses.
+func ExampleSelectBuilder_debug() {
+	sb := builder.NewSelect(nil).
+		Fields("id").
+		Source("users").
+		Where("age > 18").
+		OrderBy("id DESC")
+
+	fmt.Println(sb.Debug())
+	// Example output (counts may vary):
+	// ✅ SelectBuilder{fields:1, source:users, where:1, groupBy:0, having:0, orderBy:1}
+}
+
+// ExampleSelectBuilder_string demonstrates the concise, human-facing
+// status output of String(), suitable for logs or audits.
+func ExampleSelectBuilder_string() {
+	sb := builder.NewSelect(nil).
+		Fields("id").
+		Source("users").
+		Where("age > 18")
+
+	fmt.Println(sb.String())
+	// Example output (status may vary):
+	// ✅ SelectBuilder: status: ready, fields=1, conditions=1, grouped=false, sorted=false
+}

--- a/db/contract/example_test.go
+++ b/db/contract/example_test.go
@@ -24,9 +24,14 @@ func (t *myToken) SetKind(k myKind) { t.kind = k }
 func ExampleKindable() {
 	var k contract.Kindable[myKind] = &myToken{}
 	k.SetKind(Custom)
-
 	fmt.Printf("Kind=%v\n", k.Kind())
-	// Output: Kind=1
+
+	k.SetKind(Invalid)
+	fmt.Printf("Kind=%v\n", k.Kind())
+
+	// Output:
+	// Kind=1
+	// Kind=0
 }
 
 // ExampleIdentifiable demonstrates using a Field as a BaseToken.
@@ -70,8 +75,9 @@ func ExampleDebuggable() {
 	t := table.New("users", "u")
 	var d contract.Debuggable = t
 	fmt.Println(d.Debug())
+
 	// Output:
-	// ✅ Table("users u"): [raw:false, aliased:true, errored:false]
+	// Table("users u"): [raw:false, aliased:true, errored:false]
 }
 
 // ExampleErrorable demonstrates using a Table as an Errorable.
@@ -117,7 +123,7 @@ func ExampleStringable() {
 	t := table.New("users", "u")
 	var s contract.Stringable = t
 	fmt.Println(s.String())
-	// Output: ✅ Table(users AS u)
+	// Output: Table(users AS u)
 }
 
 // ExampleValidable demonstrates using a Table as a Validable.

--- a/db/token/table/example_test.go
+++ b/db/token/table/example_test.go
@@ -76,14 +76,16 @@ func ExampleToken_isValid() {
 func ExampleToken_string() {
 	t := table.New("users", "u")
 	fmt.Println(t.String())
-	// Output: ✅ Table(users AS u)
+
+	// Output: Table(users AS u)
 }
 
 // ExampleTable_Debug demonstrates Debug() output for diagnostics.
 func ExampleToken_debug() {
 	t := table.New("users u")
 	fmt.Println(t.Debug())
-	// Output: ✅ Table("users u"): [raw:false, aliased:true, errored:false]
+
+	// Output: Table("users u"): [raw:false, aliased:true, errored:false]
 }
 
 // ExampleTable_Error demonstrates handling of invalid input.
@@ -92,8 +94,9 @@ func ExampleToken_error() {
 	fmt.Println(t.String())
 	fmt.Println(t.IsErrored())
 	fmt.Println(t.Error())
+
 	// Output:
-	// ❌ Table("users AS"): invalid alias: AS
+	// Table("users AS"): invalid alias: AS
 	// true
 	// invalid alias: AS
 }

--- a/db/token/table/table.go
+++ b/db/token/table/table.go
@@ -162,7 +162,7 @@ func (t *table) Debug() string {
 	if !t.IsValid() {
 		return fmt.Sprintf("❌ Table(%q): %s {err=%v}", t.input, flags, t.err)
 	}
-	return fmt.Sprintf("✅ Table(%q): %s", t.input, flags)
+	return fmt.Sprintf("Table(%q): %s", t.input, flags)
 }
 
 // IsErrored reports whether the table was constructed with an error.
@@ -233,12 +233,12 @@ func (t *table) Render() string {
 func (t *table) String() string {
 	if !t.IsValid() {
 		// Always show original input and error
-		return fmt.Sprintf("❌ Table(%q): %v", t.input, t.err)
+		return fmt.Sprintf("Table(%q): %v", t.input, t.err)
 	}
 	if t.alias != "" {
-		return fmt.Sprintf("✅ Table(%s AS %s)", t.name, t.alias)
+		return fmt.Sprintf("Table(%s AS %s)", t.name, t.alias)
 	}
-	return fmt.Sprintf("✅ Table(%s)", t.name)
+	return fmt.Sprintf("Table(%q)", t.name)
 }
 
 // IsValid reports whether the table has a non-empty name and no error.

--- a/db/token/table/table_test.go
+++ b/db/token/table/table_test.go
@@ -219,14 +219,14 @@ func TestTable(t *testing.T) {
 
 		t.Run("Stringable", func(t *testing.T) {
 			f := table.New("table")
-			if got := f.String(); got != "✅ Table(table)" {
-				t.Errorf("expected String() 'field', got %q", got)
+			if got := f.String(); got != "Table(\"table\")" {
+				t.Errorf("expected 'Table(\"table\")', got %q", got)
 			}
 
 			// Computed expression with alias
 			f = table.New("table", "t")
-			if got := f.String(); got != "✅ Table(table AS t)" {
-				t.Errorf("expected String() 'field AS alias', got %q", got)
+			if got := f.String(); got != "Table(table AS t)" {
+				t.Errorf("expected String() 'Table(\"table AS t\")', got %q", got)
 			}
 
 			// Invalid

--- a/releases/release-notes-v1.14.0.md
+++ b/releases/release-notes-v1.14.0.md
@@ -2,7 +2,10 @@
 
 ## Highlights
 
-This release refines the database token system with a focus on **JOIN handling**, **expression resolution**, and **operator classification**. It introduces a type registry for operators, restructures type enums, and expands documentation and tests.
+This release refines the database token system with a focus on **JOIN handling**, **expression resolution**, and *
+*operator classification**. It introduces a type registry for operators, restructures type enums, and expands
+documentation and tests.  
+It also extends the **SelectBuilder** with richer join support, `WHERE`, `ORDER BY`, and pagination (`LIMIT`, `OFFSET`).
 
 ---
 
@@ -22,7 +25,8 @@ This release refines the database token system with a focus on **JOIN handling**
 - **ExpressionKind**: added `Invalid` classification; extended for aggregates, computed, functions.
 - **operator.Type**: refactored to a typed **registry** `{String, Alias, Position, Synonyms}`:
     - Deterministic `GetKnownOperators()` ordering by Position.
-    - O(1) `ParseFrom()` via reverse index; accepts symbols (`!=`, `>=`), words (`NOT IN`, `IS NULL`), aliases (`nin`, `gte`, `isnull`).
+    - O(1) `ParseFrom()` via reverse index; accepts symbols (`!=`, `>=`), words (`NOT IN`, `IS NULL`), aliases (`nin`,
+      `gte`, `isnull`).
     - Simplified `String()`, `Alias()`, `IsValid()` with registry lookups.
     - Added full GoDoc, `doc.go`, README, and 100% tests.
 
@@ -35,7 +39,8 @@ This release refines the database token system with a focus on **JOIN handling**
     - New constructors: `New`, `NewAnd`, `NewOr`.
     - Supports inline expressions, named parameters, and operator/value inputs.
     - Enforces operator/value validation (`IN`, `NOT IN`, `BETWEEN` rules).
-    - Implements all shared contracts (Kindable, Identifiable, Errorable, Debuggable, Rawable, Renderable, Stringable, Validable).
+    - Implements all shared contracts (Kindable, Identifiable, Errorable, Debuggable, Rawable, Renderable, Stringable,
+      Validable).
     - Full unit tests and examples with 100% coverage.
 
 - **Join token (`join.Token`)**:
@@ -52,11 +57,24 @@ This release refines the database token system with a focus on **JOIN handling**
 
 ---
 
+## Builder
+
+- **SelectBuilder**:
+    - Added full join support: `InnerJoin`, `LeftJoin`, `RightJoin`, `FullJoin`, `CrossJoin`, `NaturalJoin`.
+    - Supports `WHERE` conditions, `ORDER BY`, and pagination (`LIMIT`, `OFFSET`) in one consistent API.
+    - Default fallback to `SELECT *` when no fields are provided.
+    - Enhanced `Build()` aggregation across fields, joins, conditions, and pagination.
+- Examples updated in `doc.go`, `README.md`, and `example_test.go` to include join + where + ordering flows.
+
+---
+
 ## Helpers
 
-- New **helpers** package: identifier/alias validation, wildcard restrictions, reserved keywords, expression and condition resolution.
+- New **helpers** package: identifier/alias validation, wildcard restrictions, reserved keywords, expression and
+  condition resolution.
 - **Alias generation**:
-    - `GenerateAlias(prefix, expr)` produces deterministic, safe aliases by combining a two-letter prefix with a SHA-1 hash of the expression.
+    - `GenerateAlias(prefix, expr)` produces deterministic, safe aliases by combining a two-letter prefix with a SHA-1
+      hash of the expression.
 - **Expression resolution**:
     - `ResolveExpressionType` classifies identifiers, literals, aggregates, functions, and computed expressions.
     - `ResolveExpression` simplified default branch with unified invalid error handling.
@@ -75,9 +93,10 @@ This release refines the database token system with a focus on **JOIN handling**
 
 ## Documentation & Tests
 
-- Updated all `doc.go` and `README.md` across tokens and helpers.
-- Expanded `example_test.go` with identifiers, aliases, wildcards, subqueries, generated aliases.
-- 100% coverage for new types (`condition`, `identifier`, `operator`) and helpers.
+- Updated all `doc.go` and `README.md` across tokens and builder.
+- Expanded `example_test.go` with joins, subqueries, identifiers, aliases, wildcards, and classification.
+- Examples now show `WHERE`, `ORDER BY`, and pagination (`LIMIT`, `OFFSET`) together with joins.
+- 100% coverage for new tokens, helpers, and builder flows.
 
 ---
 
@@ -92,4 +111,7 @@ This release refines the database token system with a focus on **JOIN handling**
 
 ## Summary
 
-This release consolidates **type safety** with dedicated enums, introduces a robust **operator registry**, and improves **validation and documentation** across tokens. Builders now have deterministic operator resolution, cleaner join APIs, and fully tested helpers.
+This release consolidates **type safety** with dedicated enums, introduces a robust **operator registry**, and improves
+**validation and documentation** across tokens.  
+It also extends **SelectBuilder** with complete join support, conditions, ordering, and pagination — making it
+production-ready for complex SQL queries.


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- Tests follow `file → methods → cases` pattern with **PascalCase**.
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
