### PR TITLE
feat(errors): add documentation and examples for sentinel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [v1.15.0] - Upcoming
+
+### Added
+- Documentation for **db/errors**:
+    - `doc.go` overview file.
+    - `README.md` with usage examples.
+    - Example tests demonstrating sentinel error usage with `errors.Is`.
+
+### Changed
+- Improved GoDoc comments for `UnsupportedTypeError` and `InvalidIdentifierError`.
+
+### Fixed
+- Example tests now verify correct wrapping and detection of sentinel errors.
+
 ## [v1.14.0](https://github.com/entiqon/entiqon/releases/tag/v1.14.0) - 2025-09-18
 
 ### Contracts

--- a/Dockerfile-documentation
+++ b/Dockerfile-documentation
@@ -27,6 +27,7 @@ COPY db/builder/selects/README.md          docs/packages/db/builder/select.md
 COPY db/contract/README.md                 docs/packages/db/contract/overview.md
 COPY db/dialect/README.md                  docs/packages/db/dialect/overview.md
 COPY db/dialect/generic/README.md          docs/packages/db/dialect/generic.md
+COPY db/errors/README.md                   docs/packages/db/errors/overview.md
 COPY db/token/README.md                    docs/packages/db/token/overview.md
 COPY db/token/condition/README.md          docs/packages/db/token/condition.md
 COPY db/token/field/README.md              docs/packages/db/token/field.md

--- a/db/errors/README.md
+++ b/db/errors/README.md
@@ -1,0 +1,68 @@
+# 🛑 Entiqon DB Errors
+
+> Part of [Entiqon](../../) / [Database](../)
+
+The `db/errors` package defines **sentinel errors** used throughout Entiqon’s SQL
+builder (`table`, `field`, `join`, `condition`).
+
+These sentinels provide a consistent way to classify and detect common failure
+modes across constructors and validators.
+
+---
+
+## 📌 Overview
+
+Two error values are currently exported:
+
+- **`UnsupportedTypeError`**  
+  Returned when a constructor (e.g. `table.New`) receives a type that is not
+  supported.  
+  Example:
+  ```go
+  table.New(table.New("users"))
+  // → error: unsupported type; if you want to create a copy, use Clone() instead
+  ```
+
+- **`InvalidIdentifierError`**  
+  Returned when an identifier fails validation (e.g. contains invalid
+  characters).  
+  Example:
+  ```go
+  table.New("???")
+  // → error: invalid table identifier
+  ```
+
+---
+
+## 🔍 Usage with `errors.Is`
+
+Sentinel errors are intended to be checked with the Go standard library
+[`errors.Is`](https://pkg.go.dev/errors#Is):
+
+```go
+t := table.New("???")
+if errors.Is(t.Error(), dberrors.InvalidIdentifierError) {
+    log.Printf("invalid identifier: %v", t.Error())
+}
+```
+
+This allows constructors (`table.New`, `field.New`) to wrap errors with
+context-specific messages while still preserving the ability to detect the
+underlying cause.
+
+---
+
+## ✅ Testing
+
+The package includes `errors_test.go`, which provides both examples and
+table-driven tests to ensure that wrapped errors can be matched with
+`errors.Is`.
+
+Run tests with:
+
+```bash
+go test ./db/errors
+```
+
+---
+

--- a/db/errors/doc.go
+++ b/db/errors/doc.go
@@ -1,0 +1,35 @@
+// Package errors defines sentinel errors used across Entiqon’s SQL
+// builder tokens (tables, fields, joins, conditions).
+//
+// These errors provide consistent classification for common failure modes
+// such as unsupported constructor types or invalid identifier names.
+//
+// # Overview
+//
+// The package exposes sentinel error values that can be used with
+// [errors.Is] for robust error handling:
+//
+//   - [UnsupportedTypeError] is returned by constructors (e.g. table.New)
+//     when an input type is not allowed. For example:
+//
+//     table.New(table.New("users"))
+//     // → error: unsupported type; if you want to create a copy, use Clone() instead
+//
+//   - [InvalidIdentifierError] is returned when an identifier fails
+//     validation (e.g. invalid characters or format). For example:
+//
+//     table.New("???")
+//     // → error: invalid table identifier
+//
+// # Usage
+//
+// Callers should prefer [errors.Is] to detect sentinel values:
+//
+//	if errors.Is(err, errors.InvalidIdentifierError) {
+//	    log.Printf("invalid identifier: %v", err)
+//	}
+//
+// This allows context-specific constructors (table, field, etc.) to wrap
+// the base sentinel with their own diagnostic messages while preserving
+// consistent error typing.
+package errors

--- a/db/errors/errors.go
+++ b/db/errors/errors.go
@@ -1,0 +1,29 @@
+package errors
+
+import "errors"
+
+var (
+	// UnsupportedTypeError is returned by helpers.ValidateType when the input
+	// is not a raw string, but instead a token or another unsupported type.
+	//
+	// For example:
+	//   table.New(table.New("users"))
+	// will return this error, suggesting the caller use Clone() instead
+	// of nesting tokens directly.
+	UnsupportedTypeError = errors.New("unsupported type")
+
+	// InvalidIdentifierError is a sentinel error returned when an identifier
+	// (table name, field name, alias, etc.) fails validation.
+	//
+	// This error is wrapped with context-specific messages, allowing callers
+	// to distinguish identifier validation failures using errors.Is:
+	//
+	//   if errors.Is(err, errors.InvalidIdentifierError) {
+	//       // Handle invalid identifier error
+	//   }
+	//
+	// Example failures:
+	//   - table.New("???")   → invalid table identifier
+	//   - field.New("1abc") → invalid field identifier
+	InvalidIdentifierError = errors.New("invalid identifier")
+)

--- a/db/errors/errors_test.go
+++ b/db/errors/errors_test.go
@@ -1,0 +1,63 @@
+package errors_test
+
+import (
+	stdErrors "errors"
+	"fmt"
+	"testing"
+
+	"github.com/entiqon/db/errors"
+)
+
+func ExampleInvalidIdentifierError() {
+	// Simulate a validation failure for a table identifier.
+	err := fmt.Errorf("%w: name contains invalid characters", errors.InvalidIdentifierError)
+
+	if stdErrors.Is(err, errors.InvalidIdentifierError) {
+		fmt.Println("caught invalid identifier error")
+	}
+
+	// Output:
+	// caught invalid identifier error
+}
+
+func ExampleUnsupportedTypeError() {
+	// Simulate passing an unsupported type into a constructor.
+	err := fmt.Errorf("%w: type %T not allowed", errors.UnsupportedTypeError, 123)
+
+	if stdErrors.Is(err, errors.UnsupportedTypeError) {
+		fmt.Println("caught unsupported type error")
+	}
+
+	// Output:
+	// caught unsupported type error
+}
+
+func TestErrors(t *testing.T) {
+	tests := []struct {
+		name     string
+		baseErr  error
+		wrapped  error
+		expected error
+	}{
+		{
+			name:     "InvalidIdentifier",
+			baseErr:  errors.InvalidIdentifierError,
+			wrapped:  fmt.Errorf("%w: bad format", errors.InvalidIdentifierError),
+			expected: errors.InvalidIdentifierError,
+		},
+		{
+			name:     "UnsupportedType",
+			baseErr:  errors.UnsupportedTypeError,
+			wrapped:  fmt.Errorf("%w: got int", errors.UnsupportedTypeError),
+			expected: errors.UnsupportedTypeError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !stdErrors.Is(tt.wrapped, tt.expected) {
+				t.Errorf("expected errors.Is(%v, %v) to be true", tt.wrapped, tt.expected)
+			}
+		})
+	}
+}

--- a/db/errors/example_test.go
+++ b/db/errors/example_test.go
@@ -1,0 +1,28 @@
+package errors_test
+
+import (
+	stdErrors "errors"
+	"fmt"
+
+	"github.com/entiqon/db/errors"
+)
+
+func Example() {
+	// Simulate an identifier validation failure
+	err := fmt.Errorf("%w: name contains invalid characters", errors.InvalidIdentifierError)
+
+	if stdErrors.Is(err, errors.InvalidIdentifierError) {
+		fmt.Println("invalid identifier caught")
+	}
+
+	// Simulate passing unsupported type into constructor
+	err = fmt.Errorf("%w: got int", errors.UnsupportedTypeError)
+
+	if stdErrors.Is(err, errors.UnsupportedTypeError) {
+		fmt.Println("unsupported type caught")
+	}
+
+	// Output:
+	// invalid identifier caught
+	// unsupported type caught
+}

--- a/db/errors/unsupported_type.go
+++ b/db/errors/unsupported_type.go
@@ -1,9 +1,0 @@
-package errors
-
-import "errors"
-
-var (
-	// UnsupportedTypeError is returned by ValidateType when the input
-	// is a token or another unsupported value instead of a raw string.
-	UnsupportedTypeError = errors.New("unsupported type")
-)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,8 @@ nav:
           - Dialects:
               - Overview: packages/db/dialect/overview.md
               - Generic: packages/db/dialect/generic.md
+          - Errors:
+              - Overview: packages/db/errors/overview.md
           - Tokens:
               - Overview: packages/db/token/overview.md
               - Types: packages/db/token/types/identifier.md

--- a/releases/release-notes-v1.15.0.md
+++ b/releases/release-notes-v1.15.0.md
@@ -1,0 +1,13 @@
+## Release Notes (Upcoming v1.15.0)
+
+### Added
+- **db/errors** documentation:  
+  - `doc.go` overview file.  
+  - `README.md` with usage examples.  
+  - Example tests showing how to use sentinel errors with `errors.Is`.  
+
+### Changed
+- Improved GoDoc for `UnsupportedTypeError` and `InvalidIdentifierError`.  
+
+### Fixed
+- Example tests now verify correct wrapping and detection of sentinel errors.


### PR DESCRIPTION
# 📝 Contributor Quick Reference

## ✅ Before Commit
- Tests follow `file → methods → cases` pattern with **PascalCase**.
  - [x] `doc.go`
  - [x] `README.md`
  - [x] `example_test.go`
  - [x] `CHANGELOG.md`
  - [x] `release-notes-vX.Y.Z.md`

## 💬 Commit Rules
- Use **Conventional Commits**:
  - `feat(scope): ...` → new feature  
  - `fix(scope): ...` → bug fix  
  - `docs(scope): ...` → docs only  
  - `refactor(scope): ...` → no behavior change  
- Detailed commits → list features, tests, docs.  
- Squash commits → short summary.  

Examples:  
```text
feat(builder/select): add Having clause support

- New methods: Having, AndHaving, OrHaving
- Integrated into Build() after GROUP BY
- Tests, docs, examples, and release notes updated
```

## 🚀 Release Flow
1. Ensure **100% coverage**.  
2. Update **docs + examples**.  
3. Update **CHANGELOG** (under "Upcoming").  
4. Update **release notes** file.  
5. Tag & release with `gh release create`.  

## ✨ Style
- ✅ / ⛔️ markers in errors and docs.  
- Optional: add a fun closing phrase in commits, e.g.:  
  ```
  ✨ Time for Having!
  ```

---

## ✨ Notes for Reviewers

Please describe any additional context, special considerations, or follow-up work here.
